### PR TITLE
docs: eventbus broker analysis + Fase 1 implementation plan

### DIFF
--- a/docs/architecture/eventbus-broker-analysis.md
+++ b/docs/architecture/eventbus-broker-analysis.md
@@ -1,0 +1,1048 @@
+# Decisiones de Arquitectura del Bus de Eventos: Análisis de Implicaciones
+
+**Fecha:** 2026-04-20
+**Contexto:** Cuestionario de decisiones arquitectónicas para el bus de eventos que une a los cuatro servicios internos (marketplace-core, payments-core, invoice-core, compliance-core), más las integraciones con pasarelas de pago y con las aplicaciones Dart de los tres productos.
+
+**Preguntas que responde este documento:**
+1. ¿Qué intermediario (broker) usa el bus de eventos para la comunicación entre servicios?
+2. ¿Qué formato tienen los eventos y quién es la autoridad de los esquemas?
+3. ¿Cómo recibe `payments-core` las notificaciones entrantes de las pasarelas de pago?
+4. ¿Cómo consumen las tres aplicaciones Dart los servicios de los cores?
+
+**Alcance:** Análisis técnico profundo de cada opción, contrapartidas ocultas, matrices comparativas, recomendación contextualizada y señales para revisitar cada decisión en el futuro. Una sección final muestra cómo las cuatro decisiones están acopladas entre sí y qué combinaciones son incoherentes.
+
+---
+
+## Glosario rápido (para leer antes del resto)
+
+Este glosario sirve como referencia para los términos técnicos que aparecen repetidamente. La idea es introducir cada concepto una sola vez en español y no volver a usar su equivalente en inglés en el cuerpo del documento.
+
+| Término en español | Definición corta | Inglés (referencia) |
+|---|---|---|
+| Bus de eventos | Canal compartido donde los servicios publican y consumen eventos del dominio. | event bus |
+| Intermediario / broker | Componente central que almacena y entrega los mensajes del bus. | broker |
+| Publicador | Servicio que emite un evento al bus. | publisher |
+| Suscriptor / consumidor | Servicio que lee y procesa eventos del bus. | subscriber / consumer |
+| Entrega al menos una vez | Garantía de que el mensaje llega sí o sí, posiblemente duplicado. | at-least-once |
+| Entrega como máximo una vez | Garantía de que el mensaje no se duplica, pero podría perderse. | at-most-once |
+| Entrega exactamente una vez | Garantía de que el mensaje llega sin duplicados ni pérdidas. | exactly-once |
+| Rebobinado | Re-consumir eventos viejos para reconstruir estado o reprocesar. | replay |
+| Contrapresión | Mecanismo para que un consumidor lento no sature al publicador rápido. | back-pressure |
+| Orden per-llave | Garantía de que los eventos con la misma llave llegan en el orden emitido. | per-key ordering |
+| Registro de esquemas | Servicio central que guarda la definición formal de cada tipo de evento. | schema registry |
+| Cambio incompatible | Modificación del esquema que rompe a los consumidores que siguen la versión anterior. | breaking change |
+| Autoalojado | Operado por el propio equipo, no por un proveedor externo. | self-hosted |
+| Dependencia encadenada | Costo alto y difícil de revertir al migrar fuera de una tecnología. | lock-in |
+| Fuente única de verdad | El lugar canónico donde vive la definición correcta de un contrato. | source of truth |
+| Cola de mensajes muertos | Depósito para mensajes que no pudieron procesarse tras varios reintentos. | Dead Letter Queue (DLQ) |
+| Carga útil | Los datos del evento (lo que el consumidor va a procesar). | payload |
+| Formato de transmisión | Cómo se codifican los bytes del evento para viajar por la red. | wire format |
+| Notificación HTTP entrante | Llamada HTTP que un sistema externo (Stripe, etc.) hace al nuestro para avisar de un evento. | webhook |
+| Firma criptográfica | Hash que valida que la notificación viene del emisor legítimo. | webhook signature |
+| Idempotencia | Propiedad que permite ejecutar la misma operación varias veces con el mismo efecto. | idempotency |
+| Reintento con retroceso exponencial | Estrategia de reintentos con intervalos crecientes (1s, 4s, 16s, …). | exponential backoff retry |
+| Destino compartido | Situación en la que la latencia o caída de un servicio arrastra a otro. | fate-sharing |
+| Tormenta de reintentos | Amplificación de carga cuando un fallo hace que todos los clientes reintenten a la vez. | retry storm |
+| Generación de código | Producir clases de un lenguaje a partir de un archivo de esquema. | code generation |
+| Seguridad de tipos de punta a punta | Garantía de que el compilador detecta inconsistencias desde el servidor hasta el cliente. | end-to-end type safety |
+| Tubería de compilación | Secuencia automatizada de pasos para construir y publicar el código. | build pipeline |
+| Procurador / intermediario HTTP | Componente que reenvía o traduce llamadas entre cliente y servidor. | proxy |
+| Evolución del esquema | Cambios al contrato del evento a lo largo del tiempo sin romper a los consumidores existentes. | schema evolution |
+
+Acrónimos que aparecen en el documento:
+
+- **DLQ** — Cola de mensajes muertos (Dead Letter Queue)
+- **TTL** — Tiempo de vida (Time To Live)
+- **SLA** — Acuerdo de nivel de servicio (Service Level Agreement)
+- **CI** — Integración continua (Continuous Integration)
+- **ACK** — Acuse de recibo (acknowledgement)
+- **ISR** — Réplicas en sincronía (In-Sync Replicas, concepto específico de Kafka)
+- **MVP** — Producto mínimo viable (Minimum Viable Product)
+- **OSS** — Software de código abierto (Open Source Software)
+- **JVM** — Máquina virtual de Java (Java Virtual Machine)
+- **RPC** — Llamada a procedimiento remoto (Remote Procedure Call)
+- **AMQP** — Protocolo Avanzado de Encolado de Mensajes (Advanced Message Queuing Protocol, usado por RabbitMQ)
+- **IDL** — Lenguaje de definición de interfaces (Interface Definition Language, usado por Avro y Protobuf)
+- **gRPC** — Framework de llamadas remotas sobre HTTP/2 (sigla recursiva; nombre propio del framework de Google)
+- **HTTP/2** — Versión binaria del protocolo HTTP que soporta multiplexación de conexiones
+
+---
+
+## Tabla de contenidos
+
+**Parte I — Decisión 1: Intermediario del bus de eventos**
+1. [Resumen ejecutivo y recomendación para el caso concreto](#parte-i--decisión-1-intermediario-del-bus-de-eventos)
+2. [Marco de evaluación](#marco-de-evaluación)
+3. [Opción 1.A — NATS JetStream](#opción-1a--nats-jetstream)
+4. [Opción 1.B — Kafka (Confluent Cloud o Redpanda)](#opción-1b--kafka-confluent-cloud-o-redpanda)
+5. [Opción 1.C — RabbitMQ](#opción-1c--rabbitmq)
+6. [Opción 1.D — Postgres con LISTEN/NOTIFY](#opción-1d--postgres-con-listennotify)
+7. [Matriz comparativa de la decisión 1](#matriz-comparativa-de-la-decisión-1)
+8. [Señales para revisitar la decisión 1](#señales-para-revisitar-la-decisión-1)
+
+**Parte II — Decisión 2: Formato de eventos y autoridad de esquemas**
+
+9. [Marco de evaluación de la decisión 2](#marco-de-evaluación-de-la-decisión-2)
+10. [Opción 2.A — Protobuf con buf.build](#opción-2a--protobuf-con-bufbuild)
+11. [Opción 2.B — JSON con JSON Schema y Zod en un repositorio compartido](#opción-2b--json-con-json-schema-y-zod-en-un-repositorio-compartido)
+12. [Opción 2.C — CloudEvents con carga útil JSON](#opción-2c--cloudevents-con-carga-útil-json)
+13. [Opción 2.D — Avro con Confluent Schema Registry](#opción-2d--avro-con-confluent-schema-registry)
+14. [Matriz comparativa de la decisión 2](#matriz-comparativa-de-la-decisión-2)
+15. [Señales para revisitar la decisión 2](#señales-para-revisitar-la-decisión-2)
+
+**Parte III — Decisión 3: Notificaciones entrantes de pasarelas de pago**
+
+16. [Marco de evaluación de la decisión 3](#marco-de-evaluación-de-la-decisión-3)
+17. [Opción 3.A — Procesamiento asíncrono con cola de reintentos](#opción-3a--procesamiento-asíncrono-con-cola-de-reintentos)
+18. [Opción 3.B — Procesamiento síncrono bloqueante](#opción-3b--procesamiento-síncrono-bloqueante)
+19. [Opción 3.C — Modelo híbrido (síncrono para eventos críticos, asíncrono para los demás)](#opción-3c--modelo-híbrido-síncrono-para-eventos-críticos-asíncrono-para-los-demás)
+20. [Matriz comparativa de la decisión 3](#matriz-comparativa-de-la-decisión-3)
+21. [Señales para revisitar la decisión 3](#señales-para-revisitar-la-decisión-3)
+
+**Parte IV — Decisión 4: Consumo de los cores desde las aplicaciones Dart**
+
+22. [Marco de evaluación de la decisión 4](#marco-de-evaluación-de-la-decisión-4)
+23. [Opción 4.A — gRPC Dart nativo con compilación de esquemas](#opción-4a--grpc-dart-nativo-con-compilación-de-esquemas)
+24. [Opción 4.B — Procurador HTTP intermedio por aplicación](#opción-4b--procurador-http-intermedio-por-aplicación)
+25. [Opción 4.C — Puerta de enlace en Serverpod](#opción-4c--puerta-de-enlace-en-serverpod)
+26. [Matriz comparativa de la decisión 4](#matriz-comparativa-de-la-decisión-4)
+27. [Señales para revisitar la decisión 4](#señales-para-revisitar-la-decisión-4)
+
+**Parte V — Acoplamiento entre decisiones**
+
+28. [Cómo interactúan las cuatro decisiones](#cómo-interactúan-las-cuatro-decisiones)
+29. [Combinaciones incoherentes (señales de alarma)](#combinaciones-incoherentes-señales-de-alarma)
+30. [Recomendación combinada](#recomendación-combinada)
+
+**Apéndice**
+
+31. [Lista de verificación inicial (común a cualquier opción)](#apéndice-lista-de-verificación-inicial-común-a-cualquier-opción)
+32. [Referencias oficiales y lecturas recomendadas](#referencias-oficiales-y-lecturas-recomendadas)
+
+---
+
+## Parte I — Decisión 1: Intermediario del bus de eventos
+
+### Resumen ejecutivo
+
+Dado el contexto (cuatro servicios internos, un equipo pequeño, las aplicaciones Dart como consumidoras, la estética minimalista del proyecto), las dos opciones viables son:
+
+| Situación | Recomendación |
+|---|---|
+| Ya se decidió que hace falta un intermediario dedicado | **NATS JetStream**. Es la opción recomendada en el cuestionario y la respaldo. |
+| Todavía estamos antes de la fase de crecimiento y los cuatro servicios comparten la misma base Postgres | **Postgres con LISTEN/NOTIFY más el patrón de bandeja de salida (outbox pattern)**. No es deuda técnica, es dimensionar correctamente al tamaño actual. |
+| Existe certeza de querer hacer *event sourcing* (reconstruir estado desde el log completo de eventos) o alimentar analítica pesada | **Kafka**, pero asumiendo su costo operacional y su dependencia encadenada. |
+| Cualquier otro caso | Descartar RabbitMQ: su modelo mental (colas de tareas) no encaja con eventos del dominio entre servicios. |
+
+> **💡 Idea central:** Elegir el intermediario no es solo "dónde viven los mensajes". Define el modelo de consistencia entre servicios, el radio de impacto cuando algo falla, y cuánta complejidad operacional hereda el equipo **para siempre**.
+
+### Marco de evaluación
+
+Estas son las siete dimensiones que la mayoría de comparaciones públicas ignoran y que terminan doliendo en producción:
+
+1. **Semántica de entrega** — ¿el intermediario garantiza entrega al menos una vez, como máximo una vez, o exactamente una vez?
+2. **Garantías de orden** — ¿el orden se preserva por llave, por partición, globalmente, o no se preserva?
+3. **Ventana de persistencia** — ¿cuánto tiempo vive un evento no consumido antes de borrarse?
+4. **Capacidad de rebobinado** — ¿se pueden recorrer eventos históricos desde una fecha o posición? ¿a qué costo?
+5. **Comportamiento bajo contrapresión** — ¿qué pasa cuando un consumidor es más lento que el publicador?
+6. **Modo de falla** — cuando el intermediario cae, ¿qué se pierde? ¿en qué estado quedan los publicadores?
+7. **Aislamiento entre inquilinos** — si un servicio satura el bus, ¿cómo aislamos a los demás?
+
+> **💡 Idea metodológica:** Throughput (rendimiento) y precio son lo que la gente compara en internet. Las siete dimensiones anteriores son lo que predice si la elección va a doler. Que todas sean aburridas no las hace irrelevantes.
+
+---
+
+### Opción 1.A — NATS JetStream
+
+**Arquitectura interna**
+- El núcleo NATS es un protocolo de publicación y suscripción sin persistencia (disparar y olvidar).
+- JetStream es la capa superior que agrega *flujos persistentes* (registros solo de adición) más consumidores con acuses de recibo (ACK) por mensaje.
+- Los flujos se replican con el algoritmo de consenso Raft, en grupos de 1, 3 o 5 réplicas.
+
+**Implicaciones técnicas**
+- **Semántica de entrega:** por defecto, al menos una vez. Exactamente una vez es posible con doble ACK y ventana de deduplicación, pero agrega latencia aproximadamente al doble.
+- **Orden:** se preserva por "asunto" (subject). Si `payments-core` publica `payment.completed.{id_pedido}`, todos los eventos de ese pedido llegan en orden. Entre asuntos distintos, **no hay orden global**.
+- **Persistencia:** configurable por flujo (tiempo, tamaño, cantidad de mensajes). Ejemplo típico: "siete días o diez gigabytes, lo primero que ocurra".
+- **Rebobinado:** trivial y barato. Cada consumidor mantiene un cursor. Se puede crear un consumidor nuevo que reproduzca "desde ayer" en treinta segundos.
+- **Contrapresión:** tiene control de flujo nativo más un límite de "mensajes pendientes de ACK". Si un servicio procesa lento, solo su consumidor acumula retraso; los demás siguen normales.
+- **Modo de falla:** con tres réplicas y consenso Raft, tolera la caída de un nodo sin pérdida. Si se pierde el quórum, los publicadores fallan con error explícito (no hay escrituras fantasma).
+- **Aislamiento:** tiene "cuentas" nativas más separación por jerarquía de asuntos (`marketplace.>`, `payments.>`). Permite asignar cuotas y permisos por servicio.
+
+**Contrapartidas ocultas**
+- **No tiene registro de esquemas nativo.** Hay que rodarlo por separado o usar cabeceras con campo de versión. Kafka gana en este punto.
+- **La madurez de los clientes es asimétrica.** Go y NATS.js son excelentes. Python (paquete `nats-py`) y Dart son funcionales pero con menos facilidades listas para usar — por ejemplo, el cliente Dart actualmente no tiene soporte completo para el almacén clave-valor de JetStream.
+- **Observabilidad:** hay un exportador oficial para Prometheus, pero los tableros y alertas prearmados de la comunidad son menos maduros que los de Kafka.
+- **"Ligero" tiene asterisco.** El binario único es cierto, pero tres réplicas para Raft son tres nodos con sus discos y su planificación de almacenamiento.
+
+**Cuándo es la elección correcta**
+- Comunicación entre servicios internos por eventos del dominio (este caso).
+- Volumen medio (hasta unos 100 000 mensajes por segundo sin esfuerzo).
+- Equipo pequeño sin un ingeniero de operaciones dedicado.
+- Retención corta a media (horas o días, no meses).
+
+---
+
+### Opción 1.B — Kafka (Confluent Cloud o Redpanda)
+
+**Arquitectura interna**
+- Kafka clásico: intermediarios más ZooKeeper (reemplazado desde la versión 3 por KRaft), temas divididos en particiones, factor de replicación.
+- Redpanda: reescritura en C++ de la interfaz de Kafka, sin ZooKeeper, sin JVM, binario único. Compatible con los clientes Kafka.
+- Confluent Cloud: Kafka gestionado como servicio, con complementos (registro de esquemas, ksqlDB, Connect).
+
+**Implicaciones técnicas**
+- **Semántica de entrega:** al menos una vez por defecto. Exactamente una vez real con productores idempotentes y transacciones (Kafka es el único de los cuatro que implementa esto correctamente de punta a punta).
+- **Orden:** por partición. La llave de particionado determina qué eventos viajan juntos. Si se elige mal la llave, se pierde orden en casos sutiles.
+- **Persistencia:** el disco es la cola. La retención puede ser infinita (con almacenamiento por niveles en Confluent o Redpanda, se pueden conservar meses o años a costo de almacenamiento en la nube). Esto cambia la filosofía: el tema es el **registro histórico**, no solo un amortiguador.
+- **Rebobinado:** es el centro del diseño. Los consumidores eligen su posición: desde el principio, desde la última, por fecha, por número de secuencia. Esto habilita patrones como *event sourcing* y reprocesamiento masivo.
+- **Contrapresión:** los consumidores extraen (no reciben empujados). El intermediario no se ahoga con consumidores lentos; simplemente acumulan retraso.
+- **Modo de falla:** con réplicas en sincronía configuradas correctamente, cero pérdida con una o dos caídas. Pero el ajuste fino (`acks=all`, `min.insync.replicas`, prohibir elección de líder sucia) es delicado.
+- **Aislamiento:** listas de control de acceso granulares más cuotas por cliente. Confluent tiene aislamiento nativo. La versión autoalojada requiere operación cuidadosa.
+
+**Contrapartidas ocultas**
+- **El particionado es permanente.** Aumentar el número de particiones rompe el orden histórico por llave. Decisión irreversible.
+- **El rebalanceo de consumidores introduce pausas globales** cuando alguien entra o sale del grupo (segundos). Los rebalanceos adhesivos y cooperativos mitigan pero no eliminan el problema.
+- **El registro de esquemas es casi obligatorio.** Sin él, la evolución del esquema se vuelve una pesadilla. Costo operacional adicional.
+- **El modelo de precios de Confluent Cloud engaña.** "Un dólar por gigabyte producido" suena barato, pero con factor de replicación tres más consumo más egreso, facturas de cinco a diez mil dólares mensuales son rutina en startups medianas.
+- **Redpanda en versión gratuita:** muchas características (almacenamiento por niveles, transformaciones, multi-región) son solo para la edición Enterprise. La versión abierta es menos completa de lo que parece.
+
+**Cuándo es la elección correcta**
+- Event sourcing real (los eventos son la fuente única de verdad histórica).
+- Canal de datos hacia almacenes analíticos (Kafka Connect brilla aquí).
+- Volumen alto sostenido (más de 100 000 mensajes por segundo) con retención larga.
+- Equipo con experiencia o con presupuesto para Confluent.
+
+---
+
+### Opción 1.C — RabbitMQ
+
+**Arquitectura interna**
+- Orientado a colas, no a registros. El intermediario está escrito en Erlang sobre la plataforma OTP (muy robusta, pero ecosistema raro para operaciones).
+- Protocolo AMQP 0.9.1 con intercambios (directos, por difusión, por tópico, por cabeceras) que enrutan mensajes a colas.
+- La característica "Streams" (desde la versión 3.9) agrega algo parecido a los registros estilo Kafka, pero el ecosistema y el pensamiento del producto siguen centrados en colas.
+
+**Implicaciones técnicas**
+- **Semántica de entrega:** al menos una vez con ACK manuales. No hay exactamente una vez real.
+- **Orden:** primero-en-entrar-primero-en-salir por cola si hay un solo consumidor. Con varios consumidores compitiendo, el orden se pierde. Los "Streams" preservan el orden pero cambian el modelo de consumo.
+- **Persistencia:** los mensajes persistentes se escriben a disco, pero el modelo asume "consume y borra". Los mensajes viejos no se guardan históricamente salvo que se usen Streams.
+- **Rebobinado:** **no es nativo en colas clásicas**. Una vez confirmado el mensaje, se va. Con Streams sí, pero entonces se está usando RabbitMQ como un Kafka mediocre.
+- **Contrapresión:** conteo de prefetch por consumidor más control de flujo del intermediario. Si una cola crece demasiado, el intermediario puede bloquear a los publicadores (peligroso si los publicadores no manejan bien este caso).
+- **Modo de falla:** colas espejo (obsoletas) o colas de quórum (nuevas, basadas en Raft). Las colas de quórum son correctas pero más lentas que JetStream o Kafka.
+- **Aislamiento:** hosts virtuales más permisos. Útil, pero el costo por host virtual es real.
+
+**Contrapartidas ocultas**
+- **Modelo mental equivocado para el caso.** RabbitMQ piensa en colas de trabajo (distribución de tareas, llamadas remotas). Para eventos del dominio puros se siente torcido.
+- **Operación Erlang:** cuando algo sale mal, depurar el agrupamiento de nodos Erlang es una habilidad rara en equipos típicos.
+- **Panel de administración:** la mejor interfaz gráfica de los cuatro. Tablero detallado listo para usar.
+- **Clientes:** ubicuos y maduros en todos los lenguajes, incluido Dart. Mejor cobertura que NATS.
+
+**Cuándo es la elección correcta**
+- Mensajería estilo petición-respuesta (llamadas remotas).
+- Colas de tareas (cargas tipo Celery).
+- Equipos con experiencia previa en AMQP.
+- **No es la elección correcta para este caso** (eventos del dominio entre servicios).
+
+---
+
+### Opción 1.D — Postgres con LISTEN/NOTIFY
+
+**Arquitectura interna**
+- `NOTIFY canal, 'contenido'` dispara un evento transitorio dentro de la base.
+- `LISTEN canal` en una conexión abierta recibe las notificaciones.
+- Todo vive dentro de Postgres, sin tablas ni índices adicionales (aunque lo habitual es combinarlo con una tabla "bandeja de salida").
+
+**Implicaciones técnicas**
+- **Semántica de entrega:** **como máximo una vez, sin persistencia**. Si el suscriptor está desconectado en el momento de la notificación, el evento se pierde para siempre. Con el patrón de bandeja de salida (tabla más LISTEN) se obtiene al menos una vez, pero ya no es "cero infraestructura".
+- **Orden:** garantizado por el orden de las transacciones dentro del mismo canal.
+- **Persistencia:** **ninguna por defecto**. Las notificaciones son efímeras. La bandeja de salida lo resuelve, pero implica consulta periódica y marcado de procesados.
+- **Rebobinado:** imposible sin tabla de bandeja de salida. Con bandeja, trivial (es SQL).
+- **Contrapresión:** el contenido máximo es 8 kilobytes por defecto. El rendimiento está limitado por Postgres: pierde frente a intermediarios dedicados por un factor de diez a cien.
+- **Modo de falla:** si la conexión LISTEN se corta, los eventos entre la desconexión y la reconexión se pierden. Hay que combinar con consulta periódica de la bandeja para tener garantías.
+- **Aislamiento:** inexistente. Todos los canales comparten la misma base Postgres. Un servicio con pico alto afecta las consultas del resto.
+
+**Contrapartidas ocultas**
+- **"Cero infraestructura" es verdad solo el día uno.** El día que se necesite rebobinar, cola de mensajes muertos, o escalar, hay que migrar a otra cosa. La migración cuesta más que haber elegido bien desde el inicio.
+- **Conexiones persistentes:** cada suscriptor consume una conexión de Postgres. Si hay un pgBouncer en modo de transacción, LISTEN/NOTIFY **no funciona** (requiere modo de sesión).
+- **El patrón de bandeja de salida transaccional** es el correcto si se elige esta opción: se inserta el evento y el estado del negocio en la misma transacción, garantizando atomicidad. Un trabajador aparte lee la bandeja y publica. Es más simple de lo que suena y es la mejor opción para un producto mínimo viable real.
+- **Tamaño de la carga útil:** 8 kilobytes es restrictivo. Los eventos con contexto completo (por ejemplo, una factura con todas sus líneas) suelen no entrar, obligando al patrón "evento es solo el identificador, el consumidor lee la base", que acopla al consumidor con el esquema del publicador.
+
+**Cuándo es la elección correcta**
+- Producto mínimo viable con menos de mil eventos por segundo y todos los servicios compartiendo la misma Postgres.
+- Cuando el costo de introducir un intermediario nuevo (operacional y cognitivo) supera el beneficio actual.
+- Con plan explícito de migrar cuando crezca (no "quizás después").
+
+---
+
+### Matriz comparativa de la decisión 1
+
+| Dimensión | NATS JetStream | Kafka | RabbitMQ | Postgres LISTEN/NOTIFY |
+|---|---|---|---|---|
+| Semántica de entrega | Al menos una vez (exactamente una vez opcional) | Exactamente una vez real | Al menos una vez | Como máximo una vez (al menos una vez con bandeja de salida) |
+| Rebobinado | Trivial, barato | Central al diseño | No nativo (o con Streams) | Solo con bandeja de salida |
+| Orden preservado | Por asunto | Por partición | Por cola con un solo consumidor | Por canal |
+| Complejidad operacional | Baja a media | Alta | Media | Cero (ya existe) |
+| Cliente Dart | Funcional | Funcional | Excelente | Trivial (usa el controlador Postgres) |
+| Evolución del esquema | Manual | Con registro de esquemas | Manual | Manual |
+| Costo a escala | Bajo (autoalojado) | Alto (gestionado) | Medio | Marginal |
+| Costo de migrar a otro | Medio | Bajo (dependencia encadenada fuerte) | Medio | Alto (la bandeja es portable) |
+| Radio de impacto ante falla | Contenido por flujo | Contenido por tema | Contenido por host virtual | Compartido con la base del negocio |
+| Curva de aprendizaje | Baja (asuntos y flujos son intuitivos) | Alta (particiones, posiciones, rebalanceo, réplicas en sincronía) | Media (modelo AMQP) | Cero para quien ya sabe SQL |
+
+---
+
+### Señales para revisitar la decisión 1
+
+**Si se eligió Postgres con bandeja de salida, migrar a un intermediario dedicado cuando:**
+
+- [ ] El volumen sostenido supera los 5 000 eventos por segundo durante más de dos semanas.
+- [ ] Más de dos servicios corren en infraestructura separada (no comparten Postgres).
+- [ ] Aparecen requisitos de retención superior a 30 días (cumplimiento, auditoría, reprocesamiento masivo).
+- [ ] Un servicio saturando el bus afecta la latencia de consultas de negocio de otro servicio.
+- [ ] Hace falta cola de mensajes muertos nativa con políticas de reintento diferenciadas por tipo de evento.
+- [ ] La carga útil promedio de los eventos supera consistentemente los 4 kilobytes.
+
+**Si se eligió NATS JetStream, revisitar cuando:**
+
+- [ ] Hace falta un registro de esquemas con verificación de compatibilidad automática (Kafka es superior aquí).
+- [ ] Se requiere canal de datos pesado hacia un almacén analítico (Kafka Connect es superior).
+- [ ] El volumen sostenido supera los 500 000 eventos por segundo con retención de más de tres meses.
+- [ ] La garantía de entrega exactamente una vez de punta a punta se vuelve requisito estricto.
+
+**Si se eligió Kafka, revisitar cuando:**
+
+- [ ] El costo de Confluent Cloud supera el 5-10 % del presupuesto de infraestructura.
+- [ ] La complejidad operacional bloquea entregas más de lo que el producto habilita.
+- [ ] Se descubre que se está usando menos del 20 % de las capacidades que justifican Kafka.
+
+**Señales transversales de que el intermediario actual ya no sirve:**
+
+- [ ] Cada despliegue de un nuevo suscriptor requiere intervención manual.
+- [ ] La monitorización del retraso de los consumidores es improvisada, no una herramienta de primera clase.
+- [ ] Los incidentes tipo "perdimos un evento" ocurren más de una vez por trimestre.
+- [ ] Integrar a una persona nueva al patrón toma más de una semana.
+
+---
+
+## Parte II — Decisión 2: Formato de eventos y autoridad de esquemas
+
+> **💡 Idea central:** El formato de codificación y la autoridad del esquema es la decisión que más se *olvida* revisar y la que más se paga después. Los equipos que eligen "JSON porque es simple" descubren dieciocho meses después que están manteniendo tres copias del mismo contrato sin darse cuenta, y que la desviación silenciosa entre servicios causa errores que ningún verificador de tipos puede atrapar.
+
+### Marco de evaluación de la decisión 2
+
+Siete dimensiones relevantes:
+
+1. **Formato de transmisión** — ¿binario o texto?, ¿cuánto ocupa?, ¿cuánto cuesta analizarlo?
+2. **Lenguaje del esquema** — ¿cuán expresivo?, ¿soporta uniones, recursión, diccionarios?
+3. **Autoridad del esquema** — dónde vive la fuente única de verdad del contrato.
+4. **Detección de cambios incompatibles** — ¿existe una herramienta de línea de comandos que la integración continua pueda ejecutar en cada revisión?
+5. **Generación de código entre lenguajes** — ¿tiene buena calidad en TypeScript, Python y Dart por igual?
+6. **Validación en tiempo de ejecución** — ¿los mensajes inválidos se rechazan al decodificar, o pasan como basura?
+7. **Evolución hacia adelante y hacia atrás** — ¿se pueden agregar campos hoy sin romper a los consumidores de mañana?
+
+### Opción 2.A — Protobuf con buf.build
+
+**Arquitectura**
+- Archivos `.proto` como **fuente única de verdad**. Vivir en `payments-core` o en un repositorio dedicado `shared-protos`.
+- Herramienta `buf` más registro en [buf.build](https://buf.build): publicación, navegación visual, detección de cambios incompatibles, verificación de estilo.
+- Generación de código con `protoc` más extensiones: `protoc-gen-dart` (oficial), `ts-proto` o `bufbuild/protobuf-es` (TypeScript), `betterproto` (Python moderno).
+
+**Implicaciones técnicas**
+- **Formato de transmisión:** binario compacto. Los mensajes típicamente ocupan del 30 al 50 % del tamaño del JSON equivalente. Relevante a escala.
+- **Costo de análisis:** muy bajo en entornos con implementación nativa (Go, Java, C++). Aceptable en Dart, JavaScript y Python gracias al código generado.
+- **Evolución del esquema:** los campos reservados y los números de campo son contratos **inmutables**. Si se sigue la convención (nunca renumerar, nunca reutilizar un número reservado), la evolución hacia adelante y hacia atrás es fuerte.
+- **Detección de cambios incompatibles:** el comando `buf breaking` compara dos revisiones y reporta. Es integrable en la integración continua como verificación obligatoria antes de fusionar.
+- **Generación de código:** maduro en TypeScript, Python, Dart y Go. Dart tiene `protoc-gen-dart` oficial mantenido en conjunto por el equipo Dart y el equipo Protobuf.
+- **Autoridad del registro:** buf.build tiene planes gratuitos para proyectos abiertos y de pago para módulos privados. Alternativas: autoalojar la herramienta `buf`, usar Apicurio, o usar el registro de esquemas abierto.
+- **Paridad con gRPC:** si ya se usa gRPC como transporte (supuesto del caso), los mismos archivos `.proto` definen tanto las llamadas remotas como los eventos. Cero duplicación de contrato.
+
+**Contrapartidas ocultas**
+- **Depuración en registros de bitácora:** la carga útil binaria es ilegible a simple vista. Hay que invertir en herramientas auxiliares (`buf curl`, `protoc --decode`, interceptores que formateen los mensajes a texto). Inversión inicial.
+- **Código generado en Dart:** tiene funciones accesorias, chequeos de presencia, patrones de mutación propios de Protobuf. No son clases Dart idiomáticas limpias. Aceptable pero requiere entrenamiento del equipo.
+- **Dependencia encadenada moderada:** migrar fuera de Protobuf implica regenerar todo. Compensación aceptable dado el valor que aporta.
+- **Precios de buf.build:** gratuito para repositorios abiertos, de pago para módulos privados. Autoalojar la herramienta `buf` más los esquemas en Git es alternativa gratuita (se pierde solo la interfaz de navegación visual).
+
+**Cuándo es la elección correcta**
+- Ya se usa gRPC para llamadas remotas: los eventos heredan gratis el ecosistema.
+- El equipo tiene integración continua disciplinada (la detección de cambios incompatibles en la verificación previa a fusionar es requisito).
+- Varios lenguajes consumen eventos (TypeScript, Python, Dart, Go).
+
+---
+
+### Opción 2.B — JSON con JSON Schema y Zod en un repositorio compartido
+
+**Arquitectura**
+- Repositorio `shared-schemas` con JSON Schema canónico más envoltorios Zod para validación en tiempo de ejecución en TypeScript.
+- Dart y Python consumen el JSON Schema directamente con generadores de código (`quicktype`, `json_schema_to_dart`, `datamodel-code-generator`).
+- Cargas útiles codificadas como JSON UTF-8 en el bus.
+
+**Implicaciones técnicas**
+- **Formato de transmisión:** JSON texto. Ocupa dos a tres veces el tamaño de Protobuf. Lectura humana directa en registros.
+- **Costo de análisis:** rápido en JavaScript y TypeScript (nativo en V8), decente en Dart (`dart:convert`), decente en Python (`orjson` para mayor velocidad).
+- **Evolución del esquema:** JSON Schema permite propiedades adicionales, campos obligatorios, campos opcionales, uniones. Es expresivo. Pero la disciplina queda manual: no hay equivalente a los "números de campo reservados" que prevengan colisiones al renombrar.
+- **Detección de cambios incompatibles:** no hay estándar maduro equivalente a `buf breaking`. Herramientas como `json-schema-diff` u `openapi-diff` existen pero son menos completas.
+- **Zod solo sirve para TypeScript:** Dart y Python pierden la parte más atractiva (validación en tiempo de ejecución con estrechamiento de tipos).
+- **Autoridad del registro:** un repositorio Git es suficiente. No hay análogo a buf.build.
+
+**Contrapartidas ocultas**
+- **Duplicación con Protobuf:** si ya existen archivos `.proto` para gRPC, ahora hay que mantener dos contratos: Protobuf para las llamadas remotas y JSON Schema para los eventos. **Probabilidad de desviación entre ambos cercana al 100 % en doce meses.**
+- **Zod exclusivo de TypeScript:** el centro de gravedad de la validación queda en TypeScript. Los consumidores Dart y Python validan manualmente o no validan.
+- **Alta facilidad de depuración:** `grep`, `jq`, cualquier visor de registros lo entiende. Es el mayor atractivo real de esta opción.
+- **Esquemas versionados en repositorio compartido:** requiere estrategia de ramas más control de versiones semántico del repositorio de esquemas. Carga operacional de la que poca gente habla.
+
+**Cuándo es la elección correcta**
+- No hay archivos Protobuf ya establecidos (no es este caso).
+- Las herramientas internas son mayoritariamente TypeScript.
+- Se prioriza la facilidad de depuración sobre la eficiencia en cable.
+
+---
+
+### Opción 2.C — CloudEvents con carga útil JSON
+
+**Arquitectura**
+- Sobre estándar de CloudEvents (proyecto de la Cloud Native Computing Foundation) con campos fijos: identificador, origen, tipo, tipo de contenido, fecha, sujeto.
+- La carga útil (campo `data`) es agnóstica: puede ser JSON, Protobuf o Avro.
+- Ecosistema: OpenTelemetry, Knative, Dapr, AWS EventBridge.
+
+**Implicaciones técnicas**
+- **Estandarización del sobre:** interoperabilidad real con sistemas externos que hablan CloudEvents nativamente (EventBridge, Dapr, disparadores Knative).
+- **Sobrecarga del sobre:** unos 200 bytes por evento. No significativo en la mayoría de los casos.
+- **Esquema de la carga útil:** sigue haciendo falta JSON Schema o Protobuf para definir los datos. CloudEvents no resuelve eso.
+- **Herramientas:** clientes oficiales en Go, Java, JavaScript y Python. **Dart: no hay cliente oficial**, solo paquetes de terceros de madurez variable.
+
+**Contrapartidas ocultas**
+- **Doble mantenimiento de esquema:** sobre CloudEvents (fijo, no se toca) más esquema de la carga útil (propio). No suena mal, pero muchos equipos terminan no usando los campos del sobre en la práctica, con lo cual el envoltorio se vuelve puro costo adicional.
+- **El valor real emerge cuando hay integración externa** con sistemas que hablan CloudEvents. Para eventos puramente internos entre servicios del mismo equipo, el retorno de la inversión es dudoso.
+- **Soporte débil en Dart:** habría que implementar la codificación y decodificación del sobre manualmente o aceptar un paquete de terceros sin garantías.
+
+**Cuándo es la elección correcta**
+- Se va a integrar con EventBridge, Knative, Dapr u otros consumidores nativos de CloudEvents.
+- Hace falta un sobre estándar para enrutamiento y filtrado entre equipos u organizaciones.
+
+---
+
+### Opción 2.D — Avro con Confluent Schema Registry
+
+**Arquitectura**
+- Archivos Avro con su lenguaje de definición de interfaces. Los esquemas compilados se convierten en `.avsc`. El formato en cable es binario con un identificador de esquema en la cabecera del mensaje.
+- Confluent Schema Registry (o Apicurio como alternativa abierta) resuelve el identificador de esquema al momento de decodificar.
+- Los consumidores almacenan en memoria los esquemas ya conocidos y consultan al registro cuando encuentran uno nuevo.
+
+**Implicaciones técnicas**
+- **Formato de transmisión:** binario super compacto, incluso más que Protobuf en algunos casos (no hay números de etiqueta repetidos en cada campo).
+- **Evolución del esquema:** excelente. Avro fue diseñado alrededor de esto; el Schema Registry hace cumplir las reglas de compatibilidad (hacia adelante, hacia atrás, total) al momento de publicar.
+- **Consulta al registro en tiempo de ejecución:** cada decodificación puede requerir resolver el identificador si no está en caché. Agrega latencia y un nuevo modo de falla (si el registro cae, no se puede decodificar).
+- **Dependencia fuerte de Kafka:** el patrón "identificador de esquema en la cabecera más consulta al registro" es idiomático de Kafka. Fuera de ese ecosistema es complicado y poco natural.
+
+**Contrapartidas ocultas**
+- **Fuera de Kafka, Avro es peso muerto:** agrega la dependencia operacional del registro sin el valor que lo justifica.
+- **Clientes Dart:** poco maduros. Java, Go y Python están bien; Dart queda huérfano.
+- **Modo de falla en la resolución del esquema:** si el registro está caído, los consumidores que encuentran un identificador no conocido fallan. Requiere estrategia de caché más plan de respaldo.
+
+**Cuándo es la elección correcta**
+- **El intermediario es Kafka.** Literal — Avro pierde todo su valor fuera de ese ecosistema.
+
+---
+
+### Matriz comparativa de la decisión 2
+
+| Dimensión | Protobuf + buf | JSON + Zod | CloudEvents + JSON | Avro + Confluent |
+|---|---|---|---|---|
+| Tamaño del mensaje (vs. JSON como referencia) | 30-50 % | 100 % (referencia) | ~110 % (sobre) | 20-40 % |
+| Depuración en registros | Requiere herramientas auxiliares | Trivial (jq, grep) | Trivial | Requiere herramientas auxiliares |
+| Evolución del esquema | Fuerte (campos reservados y números de campo) | Manual, disciplina humana | Depende de la carga útil | Fuerte (registro hace cumplir) |
+| Detección de cambios incompatibles | `buf breaking`, excelente | Herramientas inmaduras | Depende de la carga útil | El registro valida al publicar |
+| Generación de código TypeScript | Excelente (ts-proto, protobuf-es) | Manual más Zod | Manual | Aceptable (ecosistema kafkajs) |
+| Generación de código Dart | Oficial, madura | De terceros (quicktype) | De terceros, no oficial | Inmadura |
+| Generación de código Python | Excelente (betterproto) | Manual más pydantic | Manual | Aceptable (confluent-kafka-python) |
+| Validación en tiempo de ejecución | Embebida en código generado | Zod solo en TypeScript | Depende de la carga útil | Vía registro más código generado |
+| Reutilización con archivos `.proto` ya existentes | Total | Duplicación | Duplicación | No aplica |
+| Costo operacional | buf.build gratuito/de pago o autoalojado | Cero | Cero extra | Operación del registro |
+| Madurez del cliente Dart | Alta | Media | Baja | Baja |
+| Severidad de la dependencia encadenada | Moderada | Baja | Baja | Alta (acoplamiento con Kafka) |
+
+---
+
+### Señales para revisitar la decisión 2
+
+**Protobuf con buf.build** es la elección correcta dado que:
+1. Ya existe `events.v1` en `payments-core` (supuesto del cuestionario).
+2. El transporte gRPC paralelo permite cero duplicación de contrato.
+3. `protoc-gen-dart` oficial es maduro.
+4. `buf breaking` en la integración continua da confianza real en la evolución.
+
+**Alternativa si no hubiera Protobuf ya establecido:** JSON más JSON Schema en el repositorio `shared-schemas`. Zod solo para ayudantes internos de TypeScript; Dart y Python consumen JSON Schema directamente con `quicktype` o `datamodel-code-generator`.
+
+**Descartar:**
+- **CloudEvents:** doble esquema sin retorno interno (reevaluar si después se integra EventBridge).
+- **Avro:** acoplamiento con Kafka sin Kafka. Solo válido si la decisión 1 es Kafka.
+
+**Revisitar la decisión 2 si:**
+
+- [ ] Se integra con tres o más sistemas externos nativos de CloudEvents → considerar envolver la carga útil Protobuf con el sobre CloudEvents (híbrido válido).
+- [ ] El costo de ancho de banda de los eventos supera el 20 % de la factura de infraestructura → revisar si JSON fue la elección.
+- [ ] Se detecta desviación entre el `.proto` (llamadas remotas) y el JSON Schema (eventos) que causa más de dos incidentes por trimestre → consolidar en Protobuf.
+- [ ] La decisión 1 migra a Kafka → evaluar Avro como segundo actor (Protobuf y Avro pueden convivir para temas distintos).
+
+---
+
+## Parte III — Decisión 3: Notificaciones entrantes de pasarelas de pago
+
+> **💡 Idea central:** La decisión entre asíncrono y síncrono no es sobre "qué es más simple", es sobre **quién asume el riesgo de las fallas de los servicios internos**. El modo síncrono delega el problema a la pasarela externa; el asíncrono lo mantiene en nuestra infraestructura con visibilidad y control. El primero se siente simple; el segundo es correcto.
+
+### Marco de evaluación de la decisión 3
+
+Dimensiones relevantes:
+
+1. **Política de reintentos de la pasarela** — Stripe reintenta con retroceso exponencial durante tres días. OnvoPay y Tilopay están menos documentadas. Expiración típica de la respuesta: 20 segundos.
+2. **Garantías de idempotencia** — las notificaciones duplicadas son la norma, no la excepción. ¿Cómo se detectan y descartan?
+3. **Momento de verificar la firma criptográfica** — con qué secreto compartido, en qué paso, qué hacer si falla.
+4. **Aislamiento ante fallas** — si el bus de eventos o la base de datos están caídos, ¿qué se responde a la pasarela?
+5. **Objetivo de tiempo de respuesta** — menos de dos segundos es ideal; menos de veinte segundos es el límite duro típico.
+6. **Observabilidad** — ¿se puede trazar una notificación desde la recepción hasta su efecto final en la base y en el bus?
+7. **Capacidad de reprocesamiento** — cuando se detecta un error, ¿se pueden reprocesar notificaciones históricas sin contactar a la pasarela?
+
+### Opción 3.A — Procesamiento asíncrono con cola de reintentos
+
+**Flujo de la arquitectura**
+1. La pasarela hace POST al punto de acceso de notificaciones de `payments-core`.
+2. `payments-core` verifica la firma criptográfica con el secreto compartido de la pasarela.
+3. Se verifica idempotencia: consulta en Redis (tiempo de vida de 24 horas) o en una tabla `webhook_events_received` por la llave `(proveedor, identificador_del_evento)`.
+4. ACK inmediato `200 OK` a la pasarela.
+5. Se encola un trabajo de procesamiento en la cola.
+6. Un trabajador asíncrono toma el trabajo, procesa (escribe en la base más publica en el bus), con reintentos de retroceso exponencial (máximo cinco intentos: 1 s, 4 s, 16 s, 64 s, 256 s → unos cinco minutos totales).
+7. Si todos los reintentos fallan → cola de mensajes muertos más alerta.
+
+**Implicaciones técnicas**
+- **Latencia hacia la pasarela:** 50 a 200 milisegundos (firma más idempotencia más encolado). Muy por debajo del límite.
+- **Aislamiento ante fallas:** bus de eventos caído o base caída no rechazan la notificación. El trabajador acumula retraso y procesa cuando los servicios internos vuelven.
+- **Idempotencia en dos niveles:** (1) tabla de notificaciones recibidas con restricción de unicidad sobre `(proveedor, identificador_del_evento)`; (2) deduplicación en el trabajador por un identificador de trabajo derivado.
+- **Reprocesamiento:** la tabla de notificaciones es la fuente única de verdad. Reprocesar equivale a re-encolar trabajos desde la tabla.
+- **Observabilidad:** un identificador de traza desde la fila de la notificación recibida → trabajo encolado → evento publicado → suscriptores, propagable si se modelan bien las cabeceras de traza.
+
+**Contrapartidas ocultas**
+- **Desacoplamiento real:** la recepción de la notificación y su procesamiento tienen objetivos de tiempo distintos. El acuerdo de nivel de servicio frente a la pasarela es estricto (responder rápido). El acuerdo de procesamiento es relajado (eventualmente). Esto es una ventaja, no un problema.
+- **La cola de mensajes muertos necesita alertas:** sin alertas, se vuelve un cementerio silencioso. Hay que integrar con PagerDuty, Slack o correo al insertar en ella.
+- **Consideración de orden:** notificaciones del mismo cliente pueden procesarse fuera de orden si el trabajador es concurrente. Mitigación: fragmentar al trabajador por identificador de cliente con enrutamiento consistente.
+- **Pruebas de punta a punta más caras:** hace falta un arnés que cubra entrada → cola → trabajador → efectos secundarios. Vale la pena, pero es inversión inicial.
+
+**Cuándo es la elección correcta**
+- Casi siempre. Es el patrón industrial estándar.
+- Especialmente cuando: hay varias pasarelas con acuerdos de nivel distintos; el volumen supera diez notificaciones por segundo; los servicios internos tienen dependencias que pueden fallar independientemente.
+
+---
+
+### Opción 3.B — Procesamiento síncrono bloqueante
+
+**Flujo de la arquitectura**
+1. La pasarela hace POST al punto de acceso.
+2. `payments-core` verifica la firma.
+3. Procesa la escritura en base más publicación en el bus **dentro del mismo request HTTP**.
+4. Responde `200 OK` si todo está bien; `5xx` si algo falla.
+5. La pasarela reintenta en caso de `5xx` según su política.
+
+**Implicaciones técnicas**
+- **Latencia hacia la pasarela:** suma de toda la cadena de procesamiento. Fácilmente más de un segundo si el bus está lento.
+- **Aislamiento ante fallas: ninguno.** Si el bus cae, todas las notificaciones devuelven `5xx` y la pasarela entra en tormenta de reintentos.
+- **Idempotencia:** sigue siendo necesaria (la pasarela reintenta). Pero el ciclo de reintentos bajo carga amplifica la sobrecarga en el peor momento posible.
+- **Reprocesamiento:** limitado. Si se procesó una notificación y luego se detecta un error, hay que reconstruir el estado manualmente.
+- **Observabilidad:** más simple, una sola traza por request.
+
+**Contrapartidas ocultas**
+- **Destino compartido:** el acuerdo de nivel frente a la pasarela queda acoplado al acuerdo de la base y el bus. Una consulta lenta durante Black Friday → reintentos de la pasarela → amplificación de carga en el peor momento.
+- **Política de reintentos de Stripe:** "si devuelves algo distinto de 2xx, reintentamos con retroceso exponencial hasta tres días". Bajo carga normal es una ventaja; bajo un error que hace fallar a todas las notificaciones, se acumulan tres días de carga esperando a que se arregle.
+- **Apariencia engañosa de simplicidad:** el código parece simple pero el comportamiento bajo fallas es complejo.
+
+**Cuándo es la elección correcta**
+- Producto mínimo viable con volumen muy bajo (menos de una notificación por segundo) y una sola pasarela.
+- **Casi nunca en producción seria.**
+
+---
+
+### Opción 3.C — Modelo híbrido (síncrono para eventos críticos, asíncrono para los demás)
+
+**Flujo de la arquitectura**
+- Enrutamiento al inicio del manejador según el tipo de evento.
+- Eventos críticos (PaymentSucceeded, RefundIssued) → ruta síncrona.
+- Eventos analíticos (actualizaciones de metadatos, desglose de comisiones) → cola asíncrona.
+
+**Implicaciones técnicas**
+- **Rutas de código mixtas:** doble superficie para pruebas, depuración, documentación, integración de personal nuevo.
+- **Los eventos críticos siguen con destino compartido:** exactamente el mismo problema que la opción 3.B, solo que restringido al subconjunto "crítico".
+- **Los eventos analíticos quedan bien aislados:** el beneficio real está aquí, pero es el subconjunto menos urgente.
+- **"Crítico" es una categoría fluida:** la lista de tipos de evento críticos cambia conforme evoluciona el producto. Cada cambio requiere revisar el enrutamiento.
+
+**Contrapartidas ocultas**
+- **La razón para lo híbrido suele ser una ilusión:** "los eventos críticos necesitan respuesta síncrona para la experiencia del usuario". Pero el estado visible al usuario (redirección después del pago, confirmación en la interfaz) **no depende de la notificación** — depende de la devolución de llamada del kit de desarrollo de la pasarela o de la consulta periódica al objeto del pago. La notificación es para sincronizar el estado del lado servidor, que es naturalmente asíncrono.
+- **Complejidad sin ventaja clara:** el beneficio de aislar lo analítico en asíncrono se logra con "todo asíncrono" sin el costo de mantener dos rutas.
+- **Análisis posterior al incidente típico:** "debimos haber usado asíncrono siempre".
+
+**Cuándo es la elección correcta**
+- Raro. Requiere restricciones muy específicas (por ejemplo, requisito regulatorio de "procesar síncronamente" en verticales financieros regulados).
+- Stripe, OnvoPay y Tilopay no imponen tal restricción → no aplica aquí.
+
+---
+
+### Matriz comparativa de la decisión 3
+
+| Dimensión | Asíncrono con cola | Síncrono bloqueante | Híbrido |
+|---|---|---|---|
+| Latencia de respuesta a la pasarela | Menos de 200 ms | 500 ms a 2 s o más | Mixta según la ruta |
+| Aislamiento ante fallas | Alto | Ninguno | Parcial |
+| Riesgo de tormenta de reintentos bajo carga | Bajo (la pasarela ve 200 OK) | Alto | Medio |
+| Idempotencia necesaria | Sí (explícita, en dos niveles) | Sí (por los reintentos de la pasarela) | Sí |
+| Capacidad de reprocesamiento | Trivial (re-encolar desde la tabla) | Limitada | Mixta |
+| Observabilidad | Requiere propagación de traza | Traza simple por request | Requiere ambas estrategias |
+| Complejidad operacional | Media (cola más trabajador más cola de muertos) | Baja | Alta |
+| Modo de falla bajo carga | Retraso del trabajador (alertable) | Tormenta de reintentos más amplificación | Mixto |
+| Esfuerzo de pruebas | Mayor (arnés de punta a punta) | Menor (prueba unitaria del manejador) | Mayor (cubre ambas rutas) |
+| Modelo mental | Un solo patrón consistente | Un solo patrón simple | Dos patrones simultáneos |
+
+---
+
+### Señales para revisitar la decisión 3
+
+**Asíncrono con cola de reintentos** es la elección correcta. Es el patrón industrial por buenas razones. Variables a definir en la implementación:
+
+1. **Almacén de la cola:** si la decisión 1 es NATS JetStream → flujo dedicado `webhooks.inbound.{proveedor}`. Si la decisión 1 es Postgres con LISTEN/NOTIFY → tabla `webhook_jobs` con trabajador que consulta periódicamente.
+2. **Almacén de idempotencia:** Redis con tiempo de vida de 24 horas **o** tabla `webhook_events_received` con restricción de unicidad en `(proveedor, identificador_del_evento)`. Redis es más rápido; la tabla es más simple y reutilizable para reprocesamiento.
+3. **Política de reintentos:** retroceso exponencial 1 s, 4 s, 16 s, 64 s, 256 s. Después → cola de mensajes muertos más alerta obligatoria.
+4. **Verificación de firma antes del ACK:** nunca responder `200 OK` a una notificación sin haber verificado la firma. Si falla → `401`, no `200`.
+5. **Fragmentación del trabajador:** por identificador de cliente si el orden por cliente importa.
+
+**Revisitar la decisión 3 si:**
+
+- [ ] Se detecta una razón de negocio *real* para sincronía en algún tipo de evento (no percibida).
+- [ ] El retraso del trabajador supera un minuto en el percentil 99 bajo carga normal → fragmentar trabajadores por proveedor o cliente.
+- [ ] Una pasarela cambia su política de reintentos (por ejemplo, reduce la expiración de 20 a 5 segundos) → validar que el margen de latencia sigue siendo cómodo.
+- [ ] La tasa de mensajes muertos supera el 0.1 % sostenido → investigar la causa raíz antes de considerar cambios arquitectónicos.
+
+---
+
+## Parte IV — Decisión 4: Consumo de los cores desde las aplicaciones Dart
+
+> **💡 Idea central:** La pregunta real no es "¿gRPC o REST?", es "¿quién paga el costo de la seguridad de tipos de punta a punta?". gRPC nativo lo paga en la tubería de compilación (paso de generación de código, versionado del código generado). El intermediario HTTP lo paga en operación (tres servidores adicionales). La puerta de enlace Serverpod lo paga en fragmentación arquitectónica (dos patrones para tres aplicaciones). No hay opción gratis.
+
+### Marco de evaluación de la decisión 4
+
+Dimensiones:
+
+1. **Seguridad de tipos de punta a punta** — ¿el contrato del servidor llega sin pérdida al cliente Dart?
+2. **Eficiencia del transporte** — HTTP/2 binario contra HTTP/1.1 con JSON.
+3. **Complejidad de la tubería de compilación** — ¿cuánto agrega a la integración continua de cada aplicación?
+4. **Compatibilidad con Flutter Web** — ¿funciona en navegador o solo en móviles?
+5. **Soporte de transmisión continua** — ¿se soportan flujos desde el servidor nativamente?
+6. **Autenticación e intermediarios** — ¿cómo se propagan tokens, observabilidad, reintentos?
+7. **Impacto en el tamaño del paquete de la aplicación** — ¿cuánto agrega al archivo final?
+8. **Comportamiento en redes móviles** — HTTP/2 en redes móviles inestables.
+
+### Opción 4.A — gRPC Dart nativo con compilación de esquemas
+
+**Arquitectura**
+- `package:grpc` (oficial, mantenido por el equipo Dart) en `pubspec.yaml`.
+- Archivos `.proto` generados a clases Dart con `protoc --dart_out=generated/`.
+- Paso en la integración continua: `buf generate` o invocación de `protoc` antes de `flutter build`.
+- Cliente típico: `final client = MarketplaceServiceClient(channel); final resp = await client.listListings(req);`
+
+**Implicaciones técnicas**
+- **Seguridad de tipos:** total. Protobuf es la fuente única de verdad; servidor y cliente son isomorfos.
+- **Transporte:** HTTP/2 con tramas binarias. Eficiente en ancho de banda y latencia.
+- **Tubería de compilación:** agrega `protoc-gen-dart` más (opcionalmente) `buf` como dependencias de desarrollo. Un paso previo a la compilación en la integración continua.
+- **Advertencia importante sobre Flutter Web:** gRPC directo **no funciona** en navegadores — los navegadores no exponen los "tráileres" de HTTP/2 ni el control de tramas de bajo nivel. Hay que usar **gRPC-Web** con un intermediario (Envoy o `grpcwebproxy`) entre Flutter Web y el servidor. Flutter móvil (iOS y Android) funciona directo sin intermediario.
+- **Transmisión continua:** transmisión desde el servidor y bidireccional soportadas en `package:grpc`.
+- **Autenticación:** `package:grpc` soporta interceptores. Propagar el token en los metadatos es el patrón estándar.
+- **Tamaño del paquete:** `package:grpc` más el código generado agregan unos 200 a 400 kilobytes al paquete final (varía según cuántos servicios se consuman).
+- **Redes móviles:** la multiplexación de HTTP/2 ayuda, pero la recuperación tras pérdida de conexión requiere manejo explícito (reconexión con retroceso).
+
+**Contrapartidas ocultas**
+- **gRPC-Web obligatorio si hay Flutter Web en el alcance:** hay que desplegar Envoy o `grpcwebproxy`. Complejidad operacional adicional nada trivial.
+- **Fragilidad del paso de generación en la integración continua:** los fallos de `protoc` o `buf` pueden bloquear los despliegues. Mitigación: versionar el código generado (comprometerlo al repositorio) a costo de riesgo de desviación entre el `.proto` y el `.dart`.
+- **Paridad con Serverpod:** si `marketplace-core` y `payments-core` usan Serverpod, el archivo `.proto` probablemente ya lo genera Serverpod. Reutilizar ese archivo directamente — no regenerarlo.
+- **Depuración:** `grpcurl` es la herramienta principal. Los registros del cliente son binarios → hay que configurar un interceptor que formatee los mensajes a texto para poder leerlos.
+- **Modelo de errores:** los códigos de estado de gRPC (`UNAVAILABLE`, `DEADLINE_EXCEEDED`, etc.) son distintos de los códigos HTTP. Mapearlos a errores Dart idiomáticos requiere un interceptor y una convención.
+
+**Cuándo es la elección correcta**
+- Primario móvil (iOS y Android como objetivos principales). Sin salvedades.
+- El servidor ya expone gRPC nativo (estilo Serverpod o servidor gRPC directo).
+- Se prioriza la seguridad de tipos y el rendimiento sobre la simplicidad operacional.
+
+---
+
+### Opción 4.B — Procurador HTTP intermedio por aplicación
+
+**Arquitectura**
+- Cada aplicación Dart tiene su propio servidor intermediario (TypeScript con NestJS, o Python con FastAPI) que traduce REST a gRPC.
+- El cliente Dart habla REST con JSON al servidor propio.
+- El servidor propio habla gRPC a los cores.
+- Tres aplicaciones Dart → tres servidores intermediarios.
+
+**Implicaciones técnicas**
+- **Seguridad de tipos:** se rompe en la frontera REST. Hay que redefinir los tipos en Dart (manualmente o con generación desde OpenAPI).
+- **Eficiencia del transporte:** se pierde HTTP/2 entre Dart y el servidor intermediario (es REST con JSON). Se mantiene HTTP/2 entre el servidor intermediario y los cores.
+- **Tubería de compilación:** un servidor más que mantener por aplicación Dart. Tres aplicaciones son tres servidores con sus despliegues, pruebas y monitorización.
+- **Flutter Web:** funciona trivialmente. No hay que configurar gRPC-Web.
+- **Transmisión continua:** los flujos desde el servidor sobre REST son incómodos — eventos enviados por el servidor (SSE), consulta periódica larga, o WebSockets. Cada uno con sus propias compensaciones.
+- **Autenticación:** estándar, token portador en la cabecera `Authorization`.
+- **Tamaño del paquete:** menor que gRPC (solo cliente HTTP más análisis JSON).
+
+**Contrapartidas ocultas**
+- **Tres servidores intermediarios significan tres veces la carga operacional:** despliegues, monitorización, escalamiento, parches de seguridad, costo. Si son procuradores sin lógica propia, son puro costo.
+- **Riesgo alto de desviación:** cuando el `.proto` cambia en los cores, hay que actualizar los tres servidores en sincronía. Mayor superficie para olvidarse de alguno.
+- **Latencia adicional:** un salto más → 30 a 100 milisegundos extra según la región. Relevante para respuestas que el usuario ve.
+- **La ventaja real emerge solo si los servidores intermediarios agregan valor** (memoria intermedia, agregación, limitación de permisos, patrón de servidor para frontend). Si son solo procuradores, son desperdicio.
+
+**Cuándo es la elección correcta**
+- Aplicación primariamente web (se evita configurar gRPC-Web a cambio de tres servidores — compensación discutible).
+- Los servidores intermediarios tienen lógica propia (memoria intermedia, agregación, patrón de servidor para frontend).
+- El equipo prefiere mantener una pila homogénea (un solo lenguaje en el servidor intermediario, antes que aprender los patrones de `protoc`).
+
+---
+
+### Opción 4.C — Puerta de enlace en Serverpod
+
+**Arquitectura**
+- Un módulo Serverpod en los servidores que ya usan Serverpod (vertivolatam, aduanext).
+- El módulo habla gRPC a los cores internamente y expone puntos de acceso Serverpod a los clientes Dart.
+- habitanexus **no usa Serverpod** → no aplica; requiere una solución distinta.
+
+**Implicaciones técnicas**
+- **Asimetría entre aplicaciones:** dos aplicaciones usan la puerta Serverpod, una (habitanexus) usa otra solución. Resultado: dos patrones conviviendo.
+- **Seguridad de tipos:** a través de los tipos generados por Serverpod. Calidad similar a gRPC nativo si el mapeo está bien hecho.
+- **Transporte:** protocolo propio de Serverpod (binario sobre WebSocket o HTTP). No es gRPC estándar.
+- **habitanexus queda excluido:** requiere opción 4.A o 4.B en paralelo → fragmentación.
+
+**Contrapartidas ocultas**
+- **Fragmentación arquitectónica:** mantener dos patrones (puerta Serverpod más algo distinto para habitanexus) duplica la carga mental del equipo. Cada característica que toque clientes Dart requiere decidir "¿cuál aplicación?" antes de decidir "¿cómo?".
+- **Dependencia encadenada más profunda con Serverpod:** cada integración nueva con los cores requiere reimplementación vía puntos de acceso Serverpod.
+- **Si el valor de Serverpod es su experiencia nativa Dart**, migrar a gRPC directo la pierde parcialmente → la opción mezclada nunca es óptima en ninguna dimensión.
+
+**Cuándo es la elección correcta**
+- **Todas** las aplicaciones Dart usan Serverpod.
+- **No aplica aquí** (habitanexus no lo usa).
+
+---
+
+### Matriz comparativa de la decisión 4
+
+| Dimensión | gRPC Dart nativo | Procurador HTTP | Puerta Serverpod |
+|---|---|---|---|
+| Seguridad de tipos de punta a punta | Total | Rota en la frontera REST | Vía tipos de Serverpod |
+| Flutter móvil (iOS y Android) | Trivial | Trivial | Trivial |
+| Flutter Web | Requiere intermediario gRPC-Web | Trivial | Trivial |
+| Complejidad de compilación en la aplicación | Media (paso protoc en la integración continua) | Baja | Media (generación Serverpod) |
+| Carga operacional adicional | Un Envoy o grpcwebproxy (si hay web) | Tres servidores intermediarios | Dos módulos Serverpod más plan B |
+| Soporte de transmisión continua | Nativo (servidor y bidireccional) | Incómodo (SSE o WebSocket) | Vía flujos Serverpod |
+| Impacto en el tamaño del paquete | +200 a +400 KB | +50 KB (cliente HTTP) | +cliente Serverpod |
+| Reutilización del `.proto` de los cores | Directa | Duplicación en tres servidores | Envoltura parcial |
+| Riesgo de desviación al cambiar el `.proto` | Bajo (una sola fuente regenerada) | Alto (tres servidores sincronizados) | Medio |
+| Compatibilidad con habitanexus | Sí | Sí | **No** (requiere plan B separado) |
+| Latencia adicional frente a gRPC directo | ~0 (gRPC directo) | +30 a +100 ms (un salto) | ~0 (Serverpod directo) |
+
+---
+
+### Señales para revisitar la decisión 4
+
+**gRPC Dart nativo con compilación de esquemas** es la elección correcta siempre que:
+
+1. Las tres aplicaciones son primariamente móviles (iOS y Android como objetivo principal). Flutter Web es secundario o no necesario.
+2. Se está dispuesto a configurar Envoy o `grpcwebproxy` si Flutter Web se vuelve objetivo serio.
+3. Se acepta el paso de `protoc` en la integración continua (versionar el código generado mitiga la fragilidad).
+
+Si Flutter Web es crítico para al menos una de las tres aplicaciones, la compensación real es:
+- **Configuración de gRPC-Web:** un intermediario, mantiene la seguridad de tipos.
+- **Procurador HTTP:** tres servidores, se pierde la seguridad de tipos, más carga operacional.
+
+La pregunta: ¿operar un intermediario especializado o tres servidores procuradores? Generalmente uno es mejor.
+
+**Revisitar la decisión 4 si:**
+
+- [ ] Flutter Web se vuelve objetivo principal para al menos una de las tres aplicaciones.
+- [ ] Configurar Envoy con gRPC-Web genera más incidentes que los tres servidores procuradores habrían generado.
+- [ ] Llega una nueva aplicación Dart sin Serverpod → reconsiderar uniformidad.
+- [ ] El tamaño del paquete supera un megabyte y la atribución a `package:grpc` más el código generado es más del 30 % del incremento → evaluar reducción por análisis de uso muerto o envoltura parcial.
+
+---
+
+## Parte V — Acoplamiento entre decisiones
+
+### Cómo interactúan las cuatro decisiones
+
+| Si la decisión 1 es... | La decisión 2 debería ser... | La cola de la decisión 3 vive en... | La decisión 4... |
+|---|---|---|---|
+| NATS JetStream | **Protobuf** (paridad con gRPC). Avro: no. | Flujo dedicado `webhooks.inbound.{proveedor}` en JetStream | gRPC nativo (Protobuf reutilizado) |
+| Kafka | **Avro** tiene sentido (el registro hace cumplir). Protobuf también es válido. | Tema `webhooks.inbound` particionado por proveedor | gRPC nativo (Protobuf reutilizado) |
+| RabbitMQ | **Protobuf o JSON** (Avro no tiene sentido) | Cola `webhooks.inbound` con cola de mensajes muertos | gRPC nativo (Protobuf reutilizado) |
+| Postgres con LISTEN/NOTIFY | **JSON** (el límite de 8 KB y la ilegibilidad de binario en SQL descartan Protobuf) | Tabla `webhook_jobs` consultada periódicamente por un trabajador | gRPC nativo (independiente del intermediario) |
+
+### Combinaciones incoherentes (señales de alarma)
+
+- 🚩 **Postgres con LISTEN/NOTIFY más Protobuf binario** → el límite de 8 KB de la carga útil más la ilegibilidad en SQL durante depuración hacen incompatible la combinación.
+- 🚩 **Avro más cualquier intermediario que no sea Kafka** → decisión incoherente. Avro agrega complejidad sin el ecosistema que la justifica.
+- 🚩 **Notificaciones síncronas (opción 3.B) más cualquier intermediario** → el intermediario no soluciona el problema de latencia extrema de la pasarela. La elección asíncrona es ortogonal al intermediario elegido.
+- 🚩 **Puerta Serverpod (opción 4.C) con habitanexus en el alcance** → incompatible por definición (habitanexus no usa Serverpod).
+- 🚩 **Procuradores HTTP (opción 4.B) más codificación Protobuf de eventos (opción 2.A)** → los tres servidores intermediarios tendrán que analizar Protobuf y reemitir JSON, duplicando el contrato que la decisión 2 pretendía consolidar.
+
+### Recomendación combinada
+
+Para el caso concreto (cuatro servicios internos, tres aplicaciones Dart, pasarelas Stripe, OnvoPay, Tilopay, primario móvil):
+
+| Decisión | Elección |
+|---|---|
+| 1 — Intermediario | **NATS JetStream** |
+| 2 — Codificación | **Protobuf con buf.build** |
+| 3 — Notificaciones entrantes | **Asíncrono con cola de reintentos** sobre flujo JetStream `webhooks.inbound.*` |
+| 4 — Consumo desde Dart | **gRPC nativo con compilación de esquemas** (más Envoy si Flutter Web entra en el alcance) |
+
+Esta combinación maximiza:
+- Reutilización de los archivos `.proto` entre llamadas remotas, eventos y notificaciones entrantes.
+- Aislamiento ante fallas entre pasarelas, bus y base.
+- Seguridad de tipos de punta a punta entre lenguajes.
+- Simplicidad operacional (un intermediario, una autoridad de esquemas, un intermediario HTTP solo si hace falta web).
+
+Y minimiza:
+- Duplicación de contratos (Protobuf como fuente única de verdad).
+- Superficie operacional (NATS es simple de operar; Envoy solo si la situación lo exige).
+- Desviación entre componentes.
+
+---
+
+## Parte VI — Estado actual del ecosistema y gaps de implementación
+
+> **Fecha del estudio:** 2026-04-20. Basado en auditoría read-only sobre ocho repositorios: `infraestructura-backend`, `habitanexus`, `vertivolatam`, `altrupets`, `aduanext`, `marketplace-core`, `agentic-core`, `dojocoding/dojo-os`.
+>
+> **Propósito:** las Partes I–V exponen el marco teórico de las cuatro decisiones. Esta parte contrasta ese marco con la **realidad actual** del ecosistema y documenta las decisiones implícitas ya tomadas que deberían sesgar la elección "limpia" hacia la opción que hereda menos infra nueva.
+
+### 6.1 Inventario por repositorio
+
+| Repositorio | Namespace K8s | Intermediario / mensajería actual | Transporte entre sidecares | Definición de esquemas / emisor de eventos |
+|---|---|---|---|---|
+| `infraestructura-backend` | compartido (no exclusivo) | Redis + Postgres (únicamente caché y sesiones; sin LISTEN/NOTIFY activo) | — | — |
+| `habitanexus` | ninguno (aplicación Dart/Flutter pura, sin backend todavía) | Horizon SSE de Stellar para eventos on-chain; Kindo HTTP; `trustless_work_dart` | HTTP directo + consulta periódica on-chain | Siete tipos de `EscrowEvent` generados desde el contrato Soroban |
+| `vertivolatam` | `vertivo-dev` | **EMQX MQTT 5.8.6** en Kubernetes (bloqueado al dominio IoT) | MQTT 1883 TCP / 8083 WebSocket | Tópicos de telemetría de invernaderos, sin eventos de dominio de negocio |
+| `altrupets` | Helm + Terraform (manifiestos no hallados en la auditoría) | Redis (solo caché vía `cache-manager-redis-yet`) | GraphQL + REST entre servicios | **Ningún emisor de eventos entre los diez microservicios NestJS** |
+| `aduanext` | `aduanext` (Pod singleton con tres sidecares) | Redis + `pgvector:pg16` (dev) | **gRPC loopback `127.0.0.1`** entre los tres sidecares del mismo Pod | Serverpod → `hacienda-sidecar` → `agentic-core` vía llamadas gRPC directas |
+| `marketplace-core` | (librería, no despliega por sí sola) | Puerto `EventBus` declarado en el dominio, **sin adaptador concreto** | gRPC `@grpc/grpc-js` puerto 50051 | `proto/marketplace_core.proto` (seis servicios) + diez eventos en `src/shared-kernel/events.ts` |
+| `agentic-core` | (librería, despliegue como sidecar) | Redis + Postgres + FalkorDB (memoria de agentes, no bus) | gRPC `grpc-aio` puerto 50051 | `proto/agentic_core.proto` (cinco servicios). **No publica eventos hoy** |
+
+**Observación transversal:** no existe un intermediario común del ecosistema. Cada repositorio eligió según su dominio: EMQX MQTT para IoT (Vertivolatam), Redis para caché (tres repos), y varias formas de no-elegir-nada (habitanexus, marketplace-core, altrupets entre servicios internos).
+
+---
+
+### 6.2 Sidecares y contratos proto existentes
+
+Los tres `-core` que se despliegan como sidecares tienen madurez asimétrica en los patrones operacionales:
+
+| Sidecar | Lenguaje / runtime gRPC | Archivo proto | Puerto gRPC | Revisión de salud | Observabilidad |
+|---|---|---|---|---|---|
+| `agentic-core` | Python `grpc-aio` | `proto/agentic_core.proto` (5 servicios) | 50051 (env `GRPC_PORT`) | RPC personalizado `HealthCheck()` (no estándar) | Registro con `logging` estándar de Python; sin OpenTelemetry |
+| `marketplace-core` | Node `@grpc/grpc-js` | `proto/marketplace_core.proto` (6 servicios, 50+ métodos) | 50051 | **Ausente** (no expone servicio de salud) | Sin registro estructurado detectado |
+| `payments-core` | Node `@grpc/grpc-js` | `proto/lapc506/payments_core/v1/payments_core.proto` + `events/v1/*` (14 RPC + 14 mensajes de evento) | 50051 | **`grpc.health.v1.Health` completo** (estándar del RFC) | **Pino** (registros JSON estructurados, nivel configurable) |
+
+**Todos** los sidecares se despliegan hoy como contenedores Docker autónomos (no hay patrón K8s sidecar init-container ni malla de servicios). Todos usan el puerto **50051** por defecto. La compatibilidad cross-lenguaje está verificada (Python ↔ TypeScript vía `proto3` + código generado).
+
+**Brecha crítica para observabilidad transversal:** `agentic-core` y `marketplace-core` deben migrar a `grpc.health.v1.Health` + registro estructurado (Pino en Node, `structlog` en Python) + exportador OpenTelemetry. Sin esto, un problema en el flujo de eventos cross-core no se puede correlacionar entre sidecares.
+
+---
+
+### 6.3 AduaNext como patrón de referencia multi-sidecar
+
+AduaNext es hoy el **único repositorio** del ecosistema que corre tres sidecares en un mismo Pod de Kubernetes:
+
+```
+Pod: aduanext (namespace: aduanext)
+├── Serverpod (backend Dart)         — puerto 8080
+├── hacienda-sidecar (TS, gRPC)      — puerto 50051 (loopback)
+└── agentic-core (Python, gRPC)      — puerto 50052 (loopback)
+```
+
+La comunicación entre sidecares viaja por `127.0.0.1:5005x`, eliminando latencia de red y evitando exponer puertos al exterior del Pod. **Este es el patrón de referencia** para cuando los demás repositorios integren `marketplace-core` + `payments-core` (y eventualmente `invoice-core` + `compliance-core`) como sidecares.
+
+**Implicación directa para la Decisión 1 (intermediario):** cuando los sidecares viven en el mismo Pod, un bus de eventos externo **no es estrictamente necesario**. Los eventos pueden viajar por gRPC loopback (llamada directa). El intermediario externo (NATS, Postgres, Kafka) se justifica solo cuando:
+
+- Los sidecares viven en Pods distintos (por escalado, por aislamiento, por límites de recursos).
+- Se requiere rebobinado o persistencia que sobreviva a reinicios del Pod.
+- Hay consumidores fuera del Pod (analítica, tableros, auditoría externa).
+
+Si se adopta el patrón AduaNext, la Decisión 1 se puede **posponer hasta que aparezca alguno de los tres disparadores**, y mientras tanto cada startup adopta el mismo patrón loopback.
+
+---
+
+### 6.4 Eventos de dominio emitidos hoy (verdad-en-tierra)
+
+| Repositorio | Eventos que emite hoy | Infraestructura de entrega | Observación |
+|---|---|---|---|
+| `habitanexus` | `EscrowInitialized`, `EscrowFunded`, `EscrowMilestoneStatusChanged`, `EscrowMilestoneApproved`, `EscrowReleased`, `EscrowDisputeStarted`, `EscrowDisputeResolved` | Horizon SSE de Stellar (on-chain) | No viajan por un bus interno; provienen directamente del contrato Soroban. Son consumibles por `payments-core` solo si se implementa un adaptador Stellar. |
+| `vertivolatam` | Telemetría IoT (ingesta de sensores) y eventos agronómicos (cosecha, fitopatología) | MQTT EMQX | El transporte está amarrado al namespace `vertivo-dev`. Para eventos de dominio cross-core (por ejemplo, `ProductoSolicitado` de Caja Vertivo), **no** conviene usar MQTT: es un canal IoT, no un bus de dominio. |
+| `altrupets` | (ninguno entre servicios internos) | N/A | Brecha crítica. Diez microservicios NestJS sin `EventEmitter` compartido. `DonationReceived`, `AdoptionMatched`, `SubsidyApproved` todavía no existen como eventos. |
+| `aduanext` | Transiciones de estado de la DUA (draft → validated → signed → presented → levante) y respuestas de ATENA | gRPC loopback entre los tres sidecares del mismo Pod | Los eventos de dominio fluyen Serverpod ↔ `hacienda-sidecar` ↔ `agentic-core` por gRPC directo. Sin intermediario externo. Funciona porque todos los consumidores viven en el mismo Pod. |
+| `payments-core` | Webhooks entrantes de Stripe, OnvoPay, Tilopay (pendientes de wire end-to-end) | Manejadores HTTP + verificador compartido `_shared/webhook-verifier.ts` | Patrón: verificación HMAC, idempotencia vía tabla `stripe_events`, reintentos 3x con retroceso exponencial. Es la implementación concreta de la opción 3.A. |
+
+**Lectura combinada:** hoy el único flujo de eventos de dominio en producción dentro del ecosistema `-core` es el de la DUA en AduaNext vía gRPC loopback. Para notificaciones entrantes, `payments-core` ya ha extraído el patrón asíncrono con idempotencia y reintentos (opción 3.A) a un módulo compartido reutilizable.
+
+---
+
+### 6.5 Decisiones implícitas ya tomadas
+
+Antes de adoptar una opción "limpia" en cada decisión, es honesto reconocer las decisiones **ya tomadas en producción** que actúan como restricciones o como atajos:
+
+**1. EMQX MQTT es verdad-en-tierra en Vertivolatam.** Está bloqueado a la versión 5.8.6 del operador y vive en el namespace `vertivo-dev`. Agregar un segundo intermediario (NATS, Kafka, RabbitMQ) al mismo cluster introduce doble-infraestructura con dos SLOs, dos estrategias de respaldo y dos cuadros de observabilidad. No es prohibitivo, pero es una obligación operacional que debe reconocerse.
+
+**2. `payments-core/events/v1/*.proto` ya existe con catorce mensajes de evento definidos** (fusionado en PR #16). Rechazar Protobuf (opción 2.A) requiere duplicar el contrato en otro formato y mantener ambos sincronizados. La probabilidad de desviación es alta, el beneficio marginal.
+
+**3. AduaNext ya ejecuta Dart ↔ gRPC loopback en producción** (Serverpod invoca `hacienda-sidecar` en `127.0.0.1:50051`). La opción 4.A (gRPC Dart nativo con compilación de esquemas) está probada y funciona. Las demás alternativas (procurador HTTP, puerta de enlace Serverpod) introducen capas nuevas que nadie ha validado en este ecosistema.
+
+**4. El verificador compartido `payments-core/_shared/payments-core/webhook-verifier.ts` implementa notificaciones entrantes asíncronas con idempotencia y reintentos 3x**, usando una tabla `stripe_events` en Postgres. Es la opción 3.A en implementación real, lista para que los sidecares la adopten. Las opciones 3.B (síncrono) y 3.C (híbrido) no tienen implementación existente en el ecosistema.
+
+**Lectura cruzada:** tres de las cuatro decisiones tienen una opción que ya está respaldada por código probado en el ecosistema. Adoptar esa opción significa heredar un patrón existente en vez de introducir infraestructura nueva. La decisión 1 (intermediario) es la única realmente abierta; su opción 1.A (EMQX) tiene presencia parcial pero está bloqueada al dominio IoT de Vertivolatam.
+
+---
+
+### 6.6 Brechas por decisión
+
+Cada decisión del marco (Partes I–IV) choca con brechas específicas en la implementación actual. Las tablas a continuación son el puente entre "lo teórico" y "lo que hay que implementar".
+
+#### Decisión 1 — Intermediario del bus
+
+| Brecha | Repositorio(s) afectado(s) | Acción requerida |
+|---|---|---|
+| `marketplace-core` tiene `EventBus` como interfaz sin adaptador concreto | `marketplace-core` | Implementar adaptador del intermediario elegido (p. ej. `NatsEventBusAdapter` o `PostgresOutboxEventBusAdapter`) |
+| `altrupets` no emite ningún evento entre sus diez microservicios NestJS | `altrupets` | Agregar `EventEmitter` global de NestJS (nativo) + manejadores por servicio antes de integrarse al bus del ecosistema |
+| `habitanexus` no tiene bus interno (solo eventos on-chain vía Horizon SSE) | `habitanexus` | Levantar backend NestJS o Serverpod + integración con el intermediario elegido |
+| No hay registro de esquemas ni cola de mensajes muertos en ningún repositorio | todos | Implementar como parte de la capa del intermediario elegido |
+
+#### Decisión 2 — Codificación y autoridad de esquemas
+
+| Brecha | Repositorio(s) | Acción |
+|---|---|---|
+| `payments-core/events/v1/*.proto` no está publicado todavía en el registro buf.build | `payments-core` | Publicar el módulo a `buf.build/lapc506/payments-core` con `buf push` en una tubería de CI |
+| `marketplace-core` define eventos en `src/shared-kernel/events.ts` (TypeScript puro), no en `.proto` | `marketplace-core` | Si se elige Protobuf: migrar a `.proto` y re-generar. Alternativa: generar `.proto` automáticamente desde TypeScript con una herramienta puente (menos deseable) |
+| `agentic-core` no emite eventos hoy | `agentic-core` | Definir qué eventos emite cuando implemente `AgenticCheckoutPort` (parte del trabajo ya planeado cross-repo) |
+
+#### Decisión 3 — Notificaciones entrantes de pasarelas
+
+| Brecha | Repositorio(s) | Acción |
+|---|---|---|
+| `payments-core` delega el reintento a la pasarela (sin cola propia) | `payments-core` | Decidir: mantener delegación (simpler) o agregar cola con trabajador interno para reintento controlado |
+| El verificador compartido asume Postgres + tabla `stripe_events` (una implementación de idempotencia) | `payments-core` | Confirmar si se mantiene Postgres como backend de idempotencia o se migra al flujo JetStream `webhooks.inbound.*` cuando se adopte NATS |
+
+#### Decisión 4 — Consumo desde aplicaciones Dart
+
+| Brecha | Repositorio(s) | Acción |
+|---|---|---|
+| `vertivolatam` no tiene cliente gRPC Dart configurado | `vertivolatam` | Agregar `package:grpc` a `pubspec.yaml` + compilación proto con `protoc-gen-dart` + paso en la tubería de CI |
+| `habitanexus` Flutter no tiene backend intermedio; la decisión entre procurador HTTP y gRPC nativo es bloqueante | `habitanexus` | Decidir explícitamente (el patrón AduaNext indica gRPC nativo) |
+| `aduanext` ya tiene el patrón validado (Serverpod → loopback gRPC) | `aduanext` | Replicar el patrón para consumir `marketplace-core` + `payments-core` externos si llegan a desplegarse fuera del Pod |
+
+---
+
+### 6.7 Secuencia recomendada de implementación
+
+Respetando las decisiones implícitas de §6.5 y las brechas de §6.6, la secuencia mínimamente disruptiva es:
+
+1. **Alinear sidecares existentes al estándar de `payments-core`**: agregar `grpc.health.v1.Health` + registro estructurado (Pino en Node, `structlog` en Python) + exportador OpenTelemetry en `agentic-core` y `marketplace-core`. Sin este paso, la observabilidad cross-sidecar no existe.
+2. **Resolver la Decisión 1** con el sesgo de §6.5: elegir **NATS JetStream** para el medio plazo y mientras tanto usar **el patrón de bandeja de salida sobre Postgres** para el MVP inmediato (el patrón AduaNext hace que esto sea aceptable incluso sin bus externo dedicado).
+3. **Resolver la Decisión 2** adoptando Protobuf con buf.build (opción 2.A). Es prácticamente imposible rechazarla sin duplicar el contrato existente en `payments-core/events/v1/`.
+4. **Resolver la Decisión 4** replicando el patrón de AduaNext (opción 4.A, gRPC Dart nativo con `protoc-gen-dart`). Ya está validado.
+5. **Resolver la Decisión 3** adoptando el verificador compartido que ya existe en `payments-core/_shared/payments-core/webhook-verifier.ts` (opción 3.A, asíncrono con idempotencia y reintentos). Ya está implementado.
+6. **Implementar el adaptador del intermediario en `marketplace-core`** según la decisión 1. Si el intermediario es Postgres + bandeja de salida, la implementación es trivial; si es NATS JetStream, implica agregar `nats.js` como dependencia.
+7. **Agregar `EventEmitter` global a `altrupets`** para desbloquear eventos entre los diez microservicios antes de conectarlos al bus del ecosistema.
+8. **Levantar backend NestJS (o Serverpod) en `habitanexus`** para poder participar del bus. Mientras tanto, los eventos on-chain de Stellar se ingestan vía un adaptador dedicado en `payments-core`.
+9. **Agregar clientes gRPC Dart** en `vertivolatam` y `habitanexus` usando el patrón de AduaNext.
+10. **Validar de punta a punta en `aduanext`** (el entorno con más sidecares en producción) antes de replicar a los demás programas. Cualquier brecha que aparezca en AduaNext primero es barata de corregir antes de que se manifieste en los otros cuatro.
+
+**Regla de oro:** cuando una opción ya está probada en al menos un repositorio del ecosistema, adoptarla tiene costo marginal. Introducir una opción nueva tiene costo de integración, de operación y de entrenamiento del equipo. Las Partes I–V del documento ayudan a elegir la mejor opción en términos técnicos; esta parte VI ayuda a ponderar ese "mejor" contra el costo real del cambio.
+
+---
+
+## Apéndice: Lista de verificación inicial (común a cualquier opción)
+
+Independientemente de las elecciones específicas, antes de poner el bus en producción conviene resolver:
+
+- [ ] Convención de nombres de eventos (por ejemplo, `{servicio}.{entidad}.{acción}` — `payments.invoice.paid`).
+- [ ] Estrategia de versionado del esquema (cabeceras, sufijo de nombre de archivo, registro de esquemas).
+- [ ] Política explícita de retención por tipo de evento.
+- [ ] Documentación de propiedad: qué servicio publica qué evento, quién puede consumirlo.
+- [ ] Configuración de cola de mensajes muertos o equivalente para eventos no procesables.
+- [ ] Monitorización del retraso de los consumidores más alertas.
+- [ ] Estrategia de reprocesamiento para recuperación (manual operativo documentado).
+- [ ] Prueba de carga sintética con el volumen esperado multiplicado por tres.
+
+---
+
+## Referencias oficiales y lecturas recomendadas
+
+> **URLs y IDs verificados el 2026-04-20 contra Context7 MCP.** Los identificadores con formato `/org/project` se pueden consumir directamente desde el servidor MCP `context7` (`mcp__context7__query-docs`) para obtener ejemplos de código y documentación actualizados sin salir del editor.
+
+**NATS JetStream**
+- Documentación oficial: https://docs.nats.io/nats-concepts/jetstream
+- Repositorio fuente de la documentación: https://github.com/nats-io/nats.docs
+- Context7 MCP ID: `/nats-io/nats.docs` (1 071 fragmentos, benchmark 86.82)
+- Patrones de despliegue y agrupamiento: https://docs.nats.io/running-a-nats-service/configuration/clustering/jetstream_clustering
+- Comparación de clientes por lenguaje: https://docs.nats.io/using-nats/developer/connecting
+- Clientes oficiales (IDs Context7):
+  - JavaScript / TypeScript (Deno, Node, Bun): `/nats-io/nats.js`
+  - Python (async / await): `/nats-io/nats.py`
+  - Rust: `/nats-io/nats.rs`
+
+**Kafka**
+- Documentación Apache Kafka: https://kafka.apache.org/documentation/
+- Context7 MCP ID: `/apache/kafka` (1 497 fragmentos)
+- Clientes Java de referencia: `/websites/javadoc_io_doc_org_apache_kafka_kafka-clients_4_2_0`
+- Cliente Python: `/dpkp/kafka-python`
+- Precios de Confluent Cloud: https://www.confluent.io/confluent-cloud/pricing/
+- Documentación de Redpanda: https://docs.redpanda.com/
+
+**RabbitMQ**
+- Documentación oficial (sitio actual): https://www.rabbitmq.com/
+- Colas de quórum (reemplazo de colas espejadas): https://www.rabbitmq.com/docs/quorum-queues
+- Streams: https://www.rabbitmq.com/docs/streams
+- Context7 MCP IDs:
+  - Sitio web oficial: `/rabbitmq/rabbitmq-website` (2 988 fragmentos, benchmark 86.3)
+  - Servidor y protocolos: `/rabbitmq/rabbitmq-server` (4 184 fragmentos, benchmark 81.9)
+
+**Postgres LISTEN/NOTIFY**
+- Documentación oficial: https://www.postgresql.org/docs/current/sql-notify.html
+- Patrón de bandeja de salida transaccional (microservices.io): https://microservices.io/patterns/data/transactional-outbox.html
+
+**Protobuf y buf.build**
+- Documentación Protobuf: https://protobuf.dev/
+- Context7 MCP ID: `/protocolbuffers/protocolbuffers.github.io` (13 166 fragmentos, benchmark 74)
+- Guía de proto3 (reservas y evolución): https://protobuf.dev/programming-guides/proto3/
+- Mejores prácticas (reservar números de tag, no reutilizar): https://protobuf.dev/best-practices/dos-donts/
+- buf CLI y Schema Registry: https://buf.build/docs/cli
+- Detección de cambios incompatibles (guía rápida): https://buf.build/docs/breaking/quickstart
+- Integración en CI/CD: https://buf.build/docs/bsr/ci-cd/setup
+- Context7 MCP IDs:
+  - Sitio y BSR: `/websites/buf_build` (5 695 fragmentos, benchmark 79.95)
+  - CLI en GitHub: `/bufbuild/buf`
+
+**CloudEvents**
+- Especificación oficial: https://cloudevents.io/
+- Proyecto CNCF: https://github.com/cloudevents/spec
+- Context7 MCP ID: `/cloudevents/spec` (322 fragmentos)
+- SDKs oficiales (IDs Context7):
+  - Go: `/cloudevents/sdk-go`
+  - JavaScript: `/cloudevents/sdk-javascript`
+  - Python: `/cloudevents/sdk-python`
+  - C#: `/cloudevents/sdk-csharp`
+
+**Avro y Schema Registry**
+- Documentación Avro: https://avro.apache.org/docs/
+- Context7 MCP ID: `/apache/avro` (801 fragmentos)
+- Confluent Schema Registry: https://docs.confluent.io/platform/current/schema-registry/index.html
+
+**gRPC en Dart**
+- Paquete oficial en pub.dev: https://pub.dev/packages/grpc
+- Tutorial oficial: https://grpc.io/docs/languages/dart/quickstart/
+- Context7 MCP ID: `/grpc/grpc-dart` (31 fragmentos, fuente oficial)
+- Plugin de generación de código (protoc_plugin): https://pub.dev/packages/protoc_plugin
+  - Activación: `dart pub global activate protoc_plugin`
+  - Uso típico: `protoc --dart_out=grpc:lib/src/generated -Iprotos protos/<archivo>.proto`
+- gRPC-Web (si Flutter Web entra en el alcance): https://github.com/grpc/grpc-web
+
+**Lecturas cruzadas recomendadas**
+- Martin Kleppmann, *Designing Data-Intensive Applications* — capítulos 11 (procesamiento de flujos) y 12 (futuro de los sistemas de datos).
+- Gregor Hohpe, *Enterprise Integration Patterns* — el modelo mental de cola contra registro.
+- Tyler Treat, "The SMART Way to Think About Messaging" — criterios para elegir semántica de entrega (https://bravenewgeek.com/).
+
+---
+
+*Este documento se escribió para revisión sin conexión y para conversaciones entre quienes toman la decisión. Si alguna de las cuatro decisiones cambia en el futuro, vuelve a la sección correspondiente de "Señales para revisitar" y anota el motivo real del cambio. Eso alimenta la próxima decisión arquitectónica del ecosistema con aprendizaje real, no con especulación.*

--- a/docs/superpowers/plans/2026-04-16-invoice-core-phase-1-plan.md
+++ b/docs/superpowers/plans/2026-04-16-invoice-core-phase-1-plan.md
@@ -1,0 +1,4410 @@
+# invoice-core Fase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build invoice-core v0.1 MVP — a TypeScript hexagonal library that exposes gRPC (`:50061`) + REST (`:8766`) for Costa Rica electronic invoicing v4.4 (all 7 document types via `HaciendaCRAdapter` wrapping `@dojocoding/hacienda-sdk`), Mensaje Receptor end-to-end, inbound gateway + reconciliation scaffold, Redis queue with retry + circuit breaker, PostgreSQL persistence, CertificateVault (Vault + sealed-secrets + local FS), XAdES-EPES SignatureVerifier, full observability, dual deployment (sidecar + standalone), Dockerfile + docker-compose + Helm chart + Zensical/MyST docs scaffold.
+
+**Architecture:** Hexagonal (Explicit Architecture). Primary adapters: gRPC (`:50061`) + REST (`:8766` standalone only). Application layer with 17 ports (5 fully wired in Fase 1, 12 interface-only for Fases 2-6). Pure domain with discriminated-union `Document` + `Taxpayer` + `DocumentSequence` + `Dispute` + value objects. Secondary adapters: `hacienda-cr` SDK, PostgreSQL (Drizzle), Redis (BullMQ), Vault/sealed-secrets, OTel, pino, Prometheus.
+
+**Tech Stack:** TypeScript 5.6 strict · Node 22 LTS · pnpm 9 · Vitest 2 · `@grpc/grpc-js` · buf codegen · PostgreSQL 16 · Redis 7 · Drizzle ORM · Fastify 5 · OpenTelemetry SDK · prom-client · pino · zod · `@dojocoding/hacienda-sdk` (CR v4.4 TaxAuthorityPort) · BullMQ (Redis queue) · opossum (circuit breaker) · xadesjs (signature verification).
+
+---
+
+## Source spec
+
+`/home/kvttvrsis/Documentos/GitHub/invoice-core/docs/superpowers/specs/2026-04-16-invoice-core-design.md` — sections §§3-6, §9 (capability matrix Fase 1 rows), §11 (observability), §12 (security), §14 (Fase 1 roadmap) govern this plan.
+
+**Out of scope for Fase 1** (deferred to Fases 2-7):
+- P1: DonationReceipt full flow, DonationAuthorizationPort adapter, AppraisalPort, CustomsDataPort ATENA wiring, FilingDataExportPort real aggregators, IssueExportInvoice (tipo 09) polish.
+- P2: Complemento Retenciones MX (`PACMexicoAdapter`), multi-tenant `.p12` per taxpayer, OCRPort.
+- P3: DIAN CO (`DIANColombiaAdapter`), event-driven emission.
+- P4: CFDI 4.0 completo, DIAN UBL completo.
+
+These appear in Fase 1 only as **port interfaces** and **proto stubs returning `UNIMPLEMENTED`** so that later phases can land adapters without breaking changes.
+
+---
+
+## File Structure (Fase 1)
+
+Every file created or modified in Fase 1. Paths relative to repo root `/home/kvttvrsis/Documentos/GitHub/invoice-core/`.
+
+### Root tooling (10 files)
+
+- `package.json` — pnpm workspace root, scripts (`build`, `test`, `lint`, `proto:gen`, `migrate`).
+- `pnpm-workspace.yaml` — declares `packages/*`.
+- `tsconfig.base.json` — strict TS config inherited by every package.
+- `biome.json` — linter + formatter config.
+- `vitest.config.ts` — root test config with coverage thresholds (domain ≥ 95%).
+- `vitest.setup.ts` — fake-clock helper, deterministic UUID seed.
+- `.gitignore` — `node_modules`, `dist`, `coverage`, `.env*`, `*.tsbuildinfo`, `.turbo`, `.pnpm-store`.
+- `.env.example` — documented env vars (no secrets).
+- `.nvmrc` — `22.11.0`.
+- `.github/workflows/ci.yml` — CI matrix (lint, typecheck, test, proto-lint, build, docker-smoke, helm-lint).
+
+### Proto (10 files)
+
+- `proto/invoice_core/v1/common.proto` — shared types (`UUID`, `ISODateTime`, `ISODate`, `Money`, `Decimal`, `TaxId`, `CABYS`, `Jurisdiction`, `PIIString`).
+- `proto/invoice_core/v1/document.proto` — Document + all subtypes (Invoice, Ticket, CreditNote, DebitNote, PurchaseInvoice, ExportInvoice, ReceiverMessage, DonationReceipt, WithholdingCertificate) + LineItem + TaxBreakdown.
+- `proto/invoice_core/v1/admin.proto` — `InvoiceAdmin` service (11 RPCs).
+- `proto/invoice_core/v1/inbox.proto` — `InvoiceInbox` service (4 RPCs).
+- `proto/invoice_core/v1/reporting.proto` — `InvoiceReporting` service (4 RPCs, Fase 1 returns UNIMPLEMENTED for D-101/D-104/D-103, donations stub).
+- `proto/invoice_core/v1/health.proto` — `InvoiceHealth` service (3 RPCs).
+- `proto/buf.yaml` — buf lint + breaking config.
+- `proto/buf.gen.yaml` — codegen wiring to `packages/proto`.
+- `packages/proto/package.json` — consumes generated TS.
+- `packages/proto/tsconfig.json`.
+
+### Domain layer — `packages/core/src/domain/` (31 files)
+
+Value objects:
+
+- `value-objects/uuid.ts`
+- `value-objects/iso-datetime.ts`
+- `value-objects/iso-date.ts`
+- `value-objects/decimal.ts` — bigint+scale, currency-safe.
+- `value-objects/money.ts` — `Decimal` + ISO 4217 currency.
+- `value-objects/tax-id.ts` — CR cédula física/jurídica/DIMEX/NITE + MX RFC + CO NIT.
+- `value-objects/cabys.ts` — 13-digit CABYS code with check.
+- `value-objects/gtin.ts` — GTIN-8/12/13/14 with mod10 check.
+- `value-objects/jurisdiction.ts`
+- `value-objects/country-code.ts` — ISO 3166-1 alpha-2.
+- `value-objects/unit-code.ts` — Hacienda CR unit catalog.
+- `value-objects/pii-string.ts` — redacts by default.
+- `value-objects/clave-numerica.ts` — 50-digit CR key.
+
+Entities:
+
+- `entities/taxpayer.ts`
+- `entities/foreign-receiver.ts`
+- `entities/document-sequence.ts`
+- `entities/dispute.ts`
+- `entities/document-base.ts` — abstract base for discriminated union.
+- `entities/invoice.ts` — type `INVOICE_CR`.
+- `entities/ticket.ts` — type `TICKET_CR`.
+- `entities/credit-note.ts` — type `CREDIT_NOTE_CR`.
+- `entities/debit-note.ts` — type `DEBIT_NOTE_CR`.
+- `entities/purchase-invoice.ts` — type `PURCHASE_INVOICE_CR` (08).
+- `entities/export-invoice.ts` — type `EXPORT_INVOICE_CR` (09, skeleton).
+- `entities/receiver-message.ts` — type `RECEIVER_MESSAGE_CR`.
+- `entities/donation-receipt.ts` — type `DONATION_RECEIPT_CR` (skeleton, full flow in Fase 2).
+- `entities/withholding-certificate.ts` — types `WITHHOLDING_MX` + `WITHHOLDING_CO` (skeleton).
+- `entities/line-item.ts` — with optional `customsData` + `traceabilityRef`.
+- `entities/tax-line.ts`
+- `entities/tax-breakdown.ts`
+
+Services, events, errors, barrel:
+
+- `services/state-machine.ts` — Document state transitions.
+- `services/totals-calculator.ts` — IVA + retenciones + grand total.
+- `services/clave-builder.ts` — CR 50-digit key composition.
+- `events/document-issued.ts`
+- `events/document-accepted.ts`
+- `events/document-rejected.ts`
+- `events/document-cancelled.ts`
+- `events/inbound-received.ts`
+- `events/inbound-validated.ts`
+- `events/receiver-message-submitted.ts`
+- `events/reconciliation-completed.ts`
+- `events/authority-unavailable.ts`
+- `errors.ts` — typed errors (`InvalidDocumentStateTransition`, `InvalidCabys`, `InvalidClaveNumerica`, `TaxpayerNotFound`, `CertificateExpired`, `SignatureInvalid`, `AuthorityTimeout`, `CircuitBreakerOpen`).
+- `index.ts` — public re-exports.
+
+### Application layer — `packages/core/src/app/` (30 files)
+
+Ports (17):
+
+- `ports/document-repository-port.ts`
+- `ports/sequence-repository-port.ts`
+- `ports/cabys-repository-port.ts`
+- `ports/taxpayer-repository-port.ts`
+- `ports/certificate-vault-port.ts`
+- `ports/tax-authority-port.ts`
+- `ports/donation-authorization-port.ts` — stub (Fase 2).
+- `ports/filing-data-export-port.ts` — stub (Fase 3).
+- `ports/inbound-document-gateway-port.ts`
+- `ports/signature-verifier-port.ts`
+- `ports/reconciliation-port.ts`
+- `ports/ocr-port.ts` — stub (P2).
+- `ports/appraisal-port.ts` — stub (Fase 2).
+- `ports/customs-data-port.ts` — stub (Fase 3).
+- `ports/accounting-sink-port.ts` — stub.
+- `ports/event-bus-port.ts`
+- `ports/observability-port.ts`
+- `ports/clock-port.ts` — infrastructure.
+- `ports/idempotency-port.ts` — infrastructure.
+- `ports/queue-port.ts` — infrastructure.
+
+Commands (11):
+
+- `commands/issue-invoice.ts`
+- `commands/issue-ticket.ts`
+- `commands/issue-credit-note.ts`
+- `commands/issue-debit-note.ts`
+- `commands/issue-purchase-invoice.ts`
+- `commands/issue-export-invoice.ts`
+- `commands/issue-donation-receipt.ts` — stub returning `UNIMPLEMENTED` (Fase 2).
+- `commands/issue-withholding-certificate.ts` — stub (Fase 5/6).
+- `commands/respond-to-receiver-message.ts`
+- `commands/cancel-document.ts`
+- `commands/reconcile-inbound.ts`
+
+Queries (5):
+
+- `queries/get-document-status.ts`
+- `queries/list-documents.ts`
+- `queries/check-authority-health.ts`
+- `queries/get-queue-depth.ts`
+- `queries/get-circuit-breaker-state.ts`
+
+Middleware + composition:
+
+- `middleware/tracing.ts`
+- `middleware/auth.ts`
+- `middleware/idempotency.ts`
+- `middleware/metrics.ts`
+- `middleware/pii-redaction.ts`
+- `index.ts`
+
+### Adapters — secondary (45 files)
+
+`packages/adapter-hacienda-cr/src/` (wraps `@dojocoding/hacienda-sdk`):
+
+- `index.ts`
+- `hacienda-cr-adapter.ts` — `TaxAuthorityPort` implementation.
+- `builders/invoice-builder.ts` — maps domain `Invoice` → SDK `FacturaBuilder`.
+- `builders/ticket-builder.ts`
+- `builders/credit-note-builder.ts`
+- `builders/debit-note-builder.ts`
+- `builders/purchase-invoice-builder.ts` — tipo 08.
+- `builders/export-invoice-builder.ts` — tipo 09 skeleton.
+- `builders/receiver-message-builder.ts`
+- `signer.ts` — wraps SDK XAdES-EPES signing with `CertificateVault`.
+- `submitter.ts` — wraps SDK API client with retry + circuit breaker hooks.
+- `status-poller.ts` — polls acknowledgment with backoff.
+- `errors.ts` — maps SDK errors to domain errors.
+- `metrics.ts` — `invoice_authority_*` Prometheus counters/histograms.
+- `__fixtures__/sample-p12.pem` — dev-only fake cert.
+- `__fixtures__/sample-acceptance.xml`
+
+`packages/adapter-postgres/src/`:
+
+- `schema/documents.ts`
+- `schema/document-sequences.ts`
+- `schema/cabys.ts`
+- `schema/taxpayers.ts`
+- `schema/inbound-documents.ts`
+- `schema/disputes.ts`
+- `schema/idempotency.ts`
+- `schema/outbox.ts`
+- `schema/index.ts`
+- `repositories/document-repository.ts`
+- `repositories/sequence-repository.ts` — advisory-lock per (taxpayer, branch, terminal, docType).
+- `repositories/cabys-repository.ts`
+- `repositories/taxpayer-repository.ts`
+- `repositories/inbound-repository.ts`
+- `cabys-csv-ingester.ts` — parses Hacienda CABYS CSV feed.
+- `migrations/0001_init.sql`
+- `drizzle.config.ts`
+
+`packages/adapter-vault/src/`:
+
+- `local-fs-vault.ts` — dev mode: reads `.p12` + password from filesystem.
+- `vault-credential-vault.ts` — Vault KV v2.
+- `sealed-secrets-loader.ts` — K8s sealed-secrets via projected volume.
+- `certificate-expiry-monitor.ts` — emits `CertificateVault.ExpiringSoon` events.
+
+`packages/adapter-queue/src/` (BullMQ + opossum):
+
+- `bullmq-queue.ts` — enqueue + worker.
+- `submission-worker.ts` — consumes submission jobs, calls `TaxAuthorityPort`.
+- `status-poll-worker.ts` — polls status after submission.
+- `circuit-breaker.ts` — opossum wrapper per authority.
+- `retry-policy.ts` — exponential backoff + jitter.
+
+`packages/adapter-signature/src/`:
+
+- `xades-epes-verifier.ts` — `SignatureVerifier` for CR XAdES-EPES v1.3.2.
+- `xades-policy-check.ts` — validates policy hash `Ohixl6upD6av8N7pEvDABhEL6hM=`.
+- `__fixtures__/valid-signed.xml`
+- `__fixtures__/tampered-signed.xml`
+
+`packages/adapter-inbound/src/`:
+
+- `hacienda-webhook-route.ts` — Fastify route registered by REST layer.
+- `hacienda-polling-worker.ts` — polls Hacienda inbound endpoint.
+- `inbound-parser.ts` — XML → domain `ReceiverMessage` source doc.
+
+`packages/adapter-otel/src/`:
+
+- `tracer.ts` — OTel SDK bootstrap.
+- `metrics.ts` — Prometheus exporter + histograms.
+- `logger.ts` — pino with PII redact paths.
+
+### Primary adapters / server — `packages/server/src/` (25 files)
+
+- `grpc/server.ts` — gRPC server bootstrap (`:50061`).
+- `grpc/interceptors/tracing.ts`
+- `grpc/interceptors/auth.ts`
+- `grpc/interceptors/redaction.ts`
+- `grpc/interceptors/metrics.ts`
+- `grpc/services/admin.ts` — `InvoiceAdmin` (11 RPCs).
+- `grpc/services/inbox.ts` — `InvoiceInbox` (4 RPCs).
+- `grpc/services/reporting.ts` — `InvoiceReporting` (stubs).
+- `grpc/services/health.ts` — `InvoiceHealth`.
+- `rest/fastify-app.ts` — Fastify 5 app (`:8766` standalone).
+- `rest/routes/admin.ts`
+- `rest/routes/inbox.ts`
+- `rest/routes/webhook-hacienda.ts`
+- `rest/routes/health.ts`
+- `rest/openapi.yaml`
+- `composition/wire.ts` — DI composition root.
+- `composition/config.ts` — zod-validated env.
+- `composition/mode.ts` — sidecar vs standalone toggle.
+- `bin/standalone.ts` — standalone entry (gRPC + REST both exposed).
+- `bin/sidecar.ts` — K8s sidecar entry (gRPC only, loopback).
+- `bin/migrate.ts` — runs Drizzle migrations + CABYS CSV ingest.
+- `workers/submission.ts` — spawns `SubmissionWorker`.
+- `workers/status-poll.ts`
+- `workers/inbound-polling.ts`
+- `workers/certificate-expiry.ts`
+
+### Deployment (8 files)
+
+- `Dockerfile` — multi-stage (builder + runner, non-root, healthcheck).
+- `.dockerignore`
+- `docker-compose.yml` — invoice-core + postgres + redis + vault + otel-collector + prometheus + grafana.
+- `docker-compose.dev.yml` — dev overrides.
+- `helm/invoice-core/Chart.yaml`
+- `helm/invoice-core/values.yaml`
+- `helm/invoice-core/templates/deployment.yaml`
+- `helm/invoice-core/templates/service.yaml`
+- `helm/invoice-core/templates/configmap.yaml`
+- `helm/invoice-core/templates/sealed-secret.yaml`
+- `helm/invoice-core/templates/servicemonitor.yaml`
+
+### Docs (9 files)
+
+- `docs/index.md` — Zensical landing.
+- `docs/getting-started.md`
+- `docs/architecture.md`
+- `docs/api-reference/grpc.md`
+- `docs/api-reference/rest.md`
+- `docs/adapters/hacienda-cr.md`
+- `docs/operations/deployment.md`
+- `docs/operations/observability.md`
+- `mkdocs.yml` — Zensical + MyST config.
+
+### Scripts (3 files)
+
+- `scripts/create-github-issues.sh` — bulk issue creation (Appendix A).
+- `scripts/create-github-labels.sh` — label taxonomy (Appendix B).
+- `scripts/dev-bootstrap.sh` — spin up compose, seed vault, run migrations, ingest CABYS sample.
+
+**Total Fase 1 files created/modified: ~185.**
+
+---
+
+## Global conventions
+
+- **Conventional Commits**: `feat(scope): ...`, `test(scope): ...`, `chore(scope): ...`, `docs(scope): ...`, `fix(scope): ...`, `ci(scope): ...`. Scopes: `proto`, `domain`, `app`, `hacienda-cr`, `postgres`, `vault`, `queue`, `signature`, `inbound`, `otel`, `grpc`, `rest`, `docker`, `helm`, `docs`, `ci`, `scaffold`.
+- **Security rule (PII)**: `TaxId`, `Taxpayer.name`, `LineItem.description` (when it contains client data), `ForeignReceiver` — logged only through `PIIString` + pino redact paths. Error messages use the document UUID, never the raw cédula.
+- **Security rule (credentials)**: `.p12` + password flow only through `CertificateVault`. Never read `HACIENDA_P12_PATH` in code paths that are not the Vault adapter. Tests use the `LocalFsVault` in tmp dirs.
+- **TDD**: every task writes a failing test first, then implementation, then refactor. `pnpm test --filter <package>` must be green before `git commit`.
+- **GitHub issue per task**: after the implementation + commit steps, run `gh issue create` with title `[Fase 1] Task N — <title>` and labels `phase/1` + scope. Issues retroactively track completion; the plan is the source of truth for what work exists.
+- **Port numbers** (from spec §3.3): gRPC `:50061`, REST `:8766`, Prometheus `:9465`. Distinct from `agentic-core` (`:50051`/`:8765`/`:9464`) and `compliance-core` (`:50071`/`:8767`/`:9466`) to allow multi-sidecar.
+
+---
+
+## Task 1 — pnpm workspace scaffold
+
+**Files:** `package.json`, `pnpm-workspace.yaml`, `.nvmrc`, `.gitignore`, `.env.example`, `tsconfig.base.json`.
+
+- [ ] **Step 1: Write `pnpm-workspace.yaml`**
+
+```yaml
+packages:
+  - "packages/*"
+```
+
+- [ ] **Step 2: Write root `package.json`**
+
+```json
+{
+  "name": "invoice-core",
+  "private": true,
+  "version": "0.1.0-dev",
+  "packageManager": "pnpm@9.12.0",
+  "engines": { "node": ">=22.11.0" },
+  "scripts": {
+    "build": "pnpm -r --filter './packages/*' build",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
+    "proto:gen": "buf generate --template proto/buf.gen.yaml proto",
+    "proto:lint": "buf lint proto",
+    "typecheck": "pnpm -r --filter './packages/*' typecheck",
+    "migrate": "node packages/server/dist/bin/migrate.js"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "1.9.4",
+    "@bufbuild/buf": "1.47.2",
+    "typescript": "5.6.3",
+    "vitest": "2.1.4",
+    "@vitest/coverage-v8": "2.1.4"
+  }
+}
+```
+
+- [ ] **Step 3: Write `.nvmrc`**
+
+```
+22.11.0
+```
+
+- [ ] **Step 4: Write `.gitignore`**
+
+```
+node_modules
+dist
+coverage
+.env
+.env.*
+!.env.example
+*.tsbuildinfo
+.turbo
+.pnpm-store
+*.p12
+```
+
+- [ ] **Step 5: Write `.env.example`**
+
+```
+# Postgres
+DATABASE_URL=postgres://invoice:invoice@localhost:5432/invoice_core
+
+# Redis
+REDIS_URL=redis://localhost:6379
+
+# Vault
+VAULT_ADDR=http://localhost:8200
+VAULT_TOKEN=dev-root-token
+VAULT_MOUNT=secret
+VAULT_CERT_PATH=invoice-core/certificates
+
+# Hacienda CR
+HACIENDA_ENV=sandbox                # sandbox | production
+HACIENDA_CLIENT_ID=api-stag
+HACIENDA_IDP_REALM=rut-stag
+
+# Transport
+GRPC_PORT=50061
+REST_PORT=8766
+METRICS_PORT=9465
+DEPLOYMENT_MODE=standalone          # standalone | sidecar
+
+# Observability
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+LOG_LEVEL=info
+
+# Webhook
+WEBHOOK_HMAC_SECRET_PATH=invoice-core/webhook-secrets
+```
+
+- [ ] **Step 6: Write `tsconfig.base.json`**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "sourceMap": true,
+    "skipLibCheck": true,
+    "lib": ["ES2023"],
+    "types": ["node"]
+  }
+}
+```
+
+- [ ] **Step 7: Install**
+
+Run: `pnpm install`
+Expected: `Lockfile created`, no peer-dep errors.
+
+- [ ] **Step 8: Verify Node version**
+
+Run: `node --version`
+Expected: `v22.11.0` (matches `.nvmrc`).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add pnpm-workspace.yaml package.json pnpm-lock.yaml .nvmrc .gitignore .env.example tsconfig.base.json
+git commit -m "chore(scaffold): pnpm workspace + strict tsconfig + env template"
+```
+
+- [ ] **Step 10: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 1 — pnpm workspace scaffold" \
+  --label "phase/1,scope/scaffold,type/chore" \
+  --body "Initialize pnpm monorepo with packages/* layout, strict tsconfig base, Node 22 LTS pin, env template."
+```
+
+---
+
+## Task 2 — Biome lint + format config
+
+**Files:** `biome.json`.
+
+- [ ] **Step 1: Write `biome.json`**
+
+```json
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "organizeImports": { "enabled": true },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": { "noExplicitAny": "error", "noConsoleLog": "error" },
+      "style": { "useConst": "error", "noNonNullAssertion": "error" },
+      "complexity": { "noForEach": "off" }
+    }
+  },
+  "files": {
+    "ignore": ["**/dist", "**/coverage", "**/generated", "**/*.sql", "**/__fixtures__/**"]
+  }
+}
+```
+
+- [ ] **Step 2: Add packages keeper**
+
+Create empty file `packages/.gitkeep` so `pnpm install` does not complain about missing workspaces.
+
+- [ ] **Step 3: Run lint on empty tree**
+
+Run: `pnpm lint`
+Expected: `Checked N files` where N is the small number of root config files; 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add biome.json packages/.gitkeep
+git commit -m "chore(ci): add Biome linter + formatter config"
+```
+
+- [ ] **Step 5: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 2 — Biome lint + format" \
+  --label "phase/1,scope/ci,type/chore" \
+  --body "Biome config with strict rules (no any, no console, no non-null assertion)."
+```
+
+---
+
+## Task 3 — Vitest root config + coverage thresholds
+
+**Files:** `vitest.config.ts`, `vitest.setup.ts`.
+
+- [ ] **Step 1: Write `vitest.config.ts`**
+
+```ts
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: false,
+    include: ["packages/**/*.{test,spec}.ts"],
+    exclude: ["**/dist/**", "**/generated/**", "**/*.integration.spec.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html", "lcov"],
+      thresholds: {
+        "packages/core/src/domain/**": {
+          lines: 95,
+          functions: 95,
+          statements: 95,
+          branches: 90,
+        },
+        "packages/core/src/app/**": {
+          lines: 85,
+          functions: 85,
+          statements: 85,
+          branches: 80,
+        },
+      },
+      exclude: ["**/generated/**", "**/*.test.ts", "**/*.spec.ts", "**/__fixtures__/**"],
+    },
+    setupFiles: ["./vitest.setup.ts"],
+  },
+});
+```
+
+- [ ] **Step 2: Write `vitest.setup.ts`**
+
+```ts
+import { afterEach, vi } from "vitest";
+
+/**
+ * Opt-in fake clock helper. Tests that need determinism call `useFixedClock("2026-04-16T12:00:00Z")`.
+ */
+export function useFixedClock(iso: string): void {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(iso));
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+```
+
+- [ ] **Step 3: Smoke test**
+
+Create `packages/.smoke.test.ts`:
+
+```ts
+import { expect, test } from "vitest";
+
+test("vitest boots", () => {
+  expect(1 + 1).toBe(2);
+});
+```
+
+Run: `pnpm test`
+Expected: `1 passed`.
+
+- [ ] **Step 4: Delete smoke test**
+
+```bash
+rm packages/.smoke.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vitest.config.ts vitest.setup.ts
+git commit -m "chore(ci): add Vitest config with coverage thresholds"
+```
+
+- [ ] **Step 6: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 3 — Vitest + coverage" \
+  --label "phase/1,scope/ci,type/chore" \
+  --body "Root Vitest config enforcing >=95% domain coverage."
+```
+
+---
+
+## Task 4 — GitHub Actions CI workflow
+
+**Files:** `.github/workflows/ci.yml`.
+
+- [ ] **Step 1: Write workflow**
+
+```yaml
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with: { version: 9.12.0 }
+      - uses: actions/setup-node@v4
+        with: { node-version: 22.11.0, cache: pnpm }
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with: { version: 9.12.0 }
+      - uses: actions/setup-node@v4
+        with: { node-version: 22.11.0, cache: pnpm }
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm proto:gen
+      - run: pnpm typecheck
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with: { version: 9.12.0 }
+      - uses: actions/setup-node@v4
+        with: { node-version: 22.11.0, cache: pnpm }
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm proto:gen
+      - run: pnpm test -- --coverage
+  proto-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: bufbuild/buf-setup-action@v1
+      - run: buf lint proto
+      - run: buf breaking proto --against '.git#branch=main,subdir=proto'
+  build:
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck, test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with: { version: 9.12.0 }
+      - uses: actions/setup-node@v4
+        with: { node-version: 22.11.0, cache: pnpm }
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm proto:gen
+      - run: pnpm build
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: add lint/typecheck/test/proto/build matrix"
+```
+
+- [ ] **Step 3: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 4 — CI workflow" \
+  --label "phase/1,scope/ci,type/chore" \
+  --body "Matrix CI: lint, typecheck, test+coverage, buf lint+breaking, build."
+```
+
+---
+
+## Task 5 — GitHub labels taxonomy
+
+**Files:** `scripts/create-github-labels.sh`.
+
+- [ ] **Step 1: Write script**
+
+```bash
+#!/usr/bin/env bash
+# Bootstrap GitHub label taxonomy for lapc506/invoice-core.
+# Idempotent: re-running updates existing labels via --force.
+set -euo pipefail
+
+REPO="${REPO:-lapc506/invoice-core}"
+
+label() {
+  local name="$1" color="$2" desc="$3"
+  gh label create "$name" --color "$color" --description "$desc" --repo "$REPO" --force
+}
+
+# Phase
+label "phase/1" "0e8a16" "Fase 1 — v0.1 MVP (CR full)"
+label "phase/2" "c2e0c6" "Fase 2 — v0.2 AltruPets donations"
+label "phase/3" "c5def5" "Fase 3 — v0.3 AduaNext inbound+customs"
+label "phase/4" "bfd4f2" "Fase 4 — v0.4 Vertivolatam export"
+label "phase/5" "d4c5f9" "Fase 5 — v0.5 HabitaNexus MX"
+label "phase/6" "f9d0c4" "Fase 6 — v0.6 HabitaNexus CO"
+
+# Scope
+for s in scaffold proto domain app hacienda-cr postgres vault queue signature inbound otel grpc rest docker helm docs ci; do
+  label "scope/$s" "ededed" "Touches $s module"
+done
+
+# Type
+label "type/feat"      "1d76db" "New feature"
+label "type/fix"       "d73a4a" "Bug fix"
+label "type/chore"     "cccccc" "Chore / tooling"
+label "type/docs"      "0075ca" "Documentation"
+label "type/test"      "bfe5bf" "Tests only"
+label "type/refactor"  "fbca04" "Refactor"
+
+# Security
+label "security/pii"          "b60205" "Handles PII — review for leak-safety"
+label "security/credentials"  "d93f0b" "Handles .p12 or secrets"
+label "security/signature"    "5319e7" "Touches signature / clave integrity"
+
+# Priority
+label "priority/p0" "b60205" "Blocker for Fase 1 go-live"
+label "priority/p1" "d93f0b" "Important"
+label "priority/p2" "fbca04" "Nice-to-have"
+
+echo "Labels bootstrapped on ${REPO}."
+```
+
+- [ ] **Step 2: Make executable**
+
+```bash
+chmod +x scripts/create-github-labels.sh
+```
+
+- [ ] **Step 3: Run once**
+
+```bash
+bash scripts/create-github-labels.sh
+```
+
+Expected: each `gh label create` prints either "created" or "updated". No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/create-github-labels.sh
+git commit -m "chore(ci): add GitHub labels bootstrap script"
+```
+
+- [ ] **Step 5: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 5 — Labels taxonomy" \
+  --label "phase/1,scope/ci,type/chore" \
+  --body "Bootstrap GitHub label taxonomy (phase/scope/type/security/priority)."
+```
+
+---
+
+## Task 6 — Core package skeleton
+
+**Files:** `packages/core/package.json`, `packages/core/tsconfig.json`, `packages/core/tsup.config.ts`.
+
+- [ ] **Step 1: Write `packages/core/package.json`**
+
+```json
+{
+  "name": "@lapc506/invoice-core-core",
+  "version": "0.1.0-dev",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" },
+    "./domain": { "import": "./dist/domain/index.js", "types": "./dist/domain/index.d.ts" },
+    "./app": { "import": "./dist/app/index.js", "types": "./dist/app/index.d.ts" }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "zod": "3.23.8"
+  },
+  "devDependencies": {
+    "tsup": "8.3.5",
+    "typescript": "5.6.3",
+    "vitest": "2.1.4"
+  }
+}
+```
+
+- [ ] **Step 2: Write `packages/core/tsconfig.json`**
+
+```json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "composite": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["**/*.spec.ts", "**/*.test.ts", "dist"]
+}
+```
+
+- [ ] **Step 3: Write `packages/core/tsup.config.ts`**
+
+```ts
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts", "src/domain/index.ts", "src/app/index.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: "es2023",
+});
+```
+
+- [ ] **Step 4: Create stub barrel**
+
+`packages/core/src/index.ts`:
+
+```ts
+export {};
+```
+
+- [ ] **Step 5: Install + typecheck**
+
+```bash
+pnpm install
+pnpm --filter @lapc506/invoice-core-core typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/
+git commit -m "chore(scaffold): add @lapc506/invoice-core-core package skeleton"
+```
+
+- [ ] **Step 7: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 6 — Core package skeleton" \
+  --label "phase/1,scope/scaffold,type/chore" \
+  --body "Scaffold packages/core with tsup build + subpath exports."
+```
+
+---
+
+## Task 7 — Domain value objects: UUID, ISODateTime, ISODate, Decimal
+
+**Files:** `packages/core/src/domain/value-objects/{uuid,iso-datetime,iso-date,decimal}.ts` + tests.
+
+- [ ] **Step 1: Failing test `uuid.spec.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { InvalidUuid, UUID } from "./uuid.js";
+
+describe("UUID", () => {
+  it("parses a valid v4 UUID", () => {
+    const v = UUID.parse("550e8400-e29b-41d4-a716-446655440000");
+    expect(v).toBe("550e8400-e29b-41d4-a716-446655440000");
+  });
+  it("rejects a non-UUID", () => {
+    expect(() => UUID.parse("not-a-uuid")).toThrow(InvalidUuid);
+  });
+  it("exposes isUuid type guard", () => {
+    expect(UUID.isUuid("550e8400-e29b-41d4-a716-446655440000")).toBe(true);
+    expect(UUID.isUuid("no")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+Run: `pnpm --filter @lapc506/invoice-core-core test uuid`
+Expected: cannot find module `./uuid.js`.
+
+- [ ] **Step 3: Implement `uuid.ts`**
+
+```ts
+import { z } from "zod";
+
+const schema = z.string().uuid();
+
+export type UUID = string & { readonly __brand: "UUID" };
+
+export const UUID = {
+  parse(input: unknown): UUID {
+    const r = schema.safeParse(input);
+    if (!r.success) throw new InvalidUuid(r.error.message);
+    return r.data as UUID;
+  },
+  isUuid(input: unknown): input is UUID {
+    return schema.safeParse(input).success;
+  },
+};
+
+export class InvalidUuid extends Error {
+  constructor(msg: string) {
+    super(`Invalid UUID: ${msg}`);
+    this.name = "InvalidUuid";
+  }
+}
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+Run: `pnpm --filter @lapc506/invoice-core-core test uuid`
+Expected: 3 passed.
+
+- [ ] **Step 5: Implement `iso-datetime.ts`**
+
+```ts
+import { z } from "zod";
+
+const schema = z.string().datetime({ offset: true });
+
+export type ISODateTime = string & { readonly __brand: "ISODateTime" };
+
+export const ISODateTime = {
+  parse(input: unknown): ISODateTime {
+    const r = schema.safeParse(input);
+    if (!r.success) throw new InvalidISODateTime(r.error.message);
+    return r.data as ISODateTime;
+  },
+  now(clock: () => Date = () => new Date()): ISODateTime {
+    return clock().toISOString() as ISODateTime;
+  },
+};
+
+export class InvalidISODateTime extends Error {
+  constructor(msg: string) {
+    super(`Invalid ISO datetime: ${msg}`);
+    this.name = "InvalidISODateTime";
+  }
+}
+```
+
+- [ ] **Step 6: Test `iso-datetime.spec.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { InvalidISODateTime, ISODateTime } from "./iso-datetime.js";
+
+describe("ISODateTime", () => {
+  it("parses RFC3339 with offset", () => {
+    expect(ISODateTime.parse("2026-04-16T12:00:00-06:00")).toBe("2026-04-16T12:00:00-06:00");
+  });
+  it("rejects naive datetime", () => {
+    expect(() => ISODateTime.parse("2026-04-16 12:00:00")).toThrow(InvalidISODateTime);
+  });
+  it("clock-injected now() produces deterministic output", () => {
+    const clock = () => new Date("2026-04-16T00:00:00.000Z");
+    expect(ISODateTime.now(clock)).toBe("2026-04-16T00:00:00.000Z");
+  });
+});
+```
+
+Run: `pnpm test iso-datetime` → 3 passed.
+
+- [ ] **Step 7: Implement `iso-date.ts`** (YYYY-MM-DD only, no time)
+
+```ts
+import { z } from "zod";
+
+const schema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
+
+export type ISODate = string & { readonly __brand: "ISODate" };
+
+export const ISODate = {
+  parse(input: unknown): ISODate {
+    const r = schema.safeParse(input);
+    if (!r.success) throw new InvalidISODate(r.error?.message ?? "format");
+    const d = new Date(`${r.data}T00:00:00Z`);
+    if (Number.isNaN(d.getTime())) throw new InvalidISODate("not a real date");
+    return r.data as ISODate;
+  },
+};
+
+export class InvalidISODate extends Error {
+  constructor(msg: string) {
+    super(`Invalid ISO date: ${msg}`);
+    this.name = "InvalidISODate";
+  }
+}
+```
+
+Test rejects `2026-02-30`.
+
+- [ ] **Step 8: Implement `decimal.ts`** (bigint + scale)
+
+```ts
+export class Decimal {
+  private constructor(
+    public readonly value: bigint,
+    public readonly scale: number,
+  ) {}
+
+  static of(value: bigint, scale: number): Decimal {
+    if (scale < 0 || scale > 12) throw new RangeError("scale must be in [0,12]");
+    return new Decimal(value, scale);
+  }
+
+  static fromString(s: string): Decimal {
+    const m = /^(-?)(\d+)(?:\.(\d+))?$/.exec(s);
+    if (!m) throw new InvalidDecimal(s);
+    const sign = m[1] === "-" ? -1n : 1n;
+    const whole = BigInt(m[2] ?? "0");
+    const frac = m[3] ?? "";
+    const scale = frac.length;
+    const value = sign * (whole * 10n ** BigInt(scale) + (frac === "" ? 0n : BigInt(frac)));
+    return new Decimal(value, scale);
+  }
+
+  add(other: Decimal): Decimal {
+    const [a, b, s] = align(this, other);
+    return new Decimal(a + b, s);
+  }
+
+  sub(other: Decimal): Decimal {
+    const [a, b, s] = align(this, other);
+    return new Decimal(a - b, s);
+  }
+
+  mul(other: Decimal): Decimal {
+    return new Decimal(this.value * other.value, this.scale + other.scale);
+  }
+
+  toString(): string {
+    const s = this.value.toString().replace("-", "");
+    const sign = this.value < 0n ? "-" : "";
+    if (this.scale === 0) return `${sign}${s}`;
+    const pad = s.padStart(this.scale + 1, "0");
+    return `${sign}${pad.slice(0, -this.scale)}.${pad.slice(-this.scale)}`;
+  }
+
+  equals(other: Decimal): boolean {
+    const [a, b] = align(this, other);
+    return a === b;
+  }
+}
+
+function align(a: Decimal, b: Decimal): [bigint, bigint, number] {
+  const s = Math.max(a.scale, b.scale);
+  return [a.value * 10n ** BigInt(s - a.scale), b.value * 10n ** BigInt(s - b.scale), s];
+}
+
+export class InvalidDecimal extends Error {
+  constructor(v: string) {
+    super(`Invalid decimal: ${v}`);
+    this.name = "InvalidDecimal";
+  }
+}
+```
+
+- [ ] **Step 9: Decimal test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { Decimal } from "./decimal.js";
+
+describe("Decimal", () => {
+  it("parses, adds, preserves scale", () => {
+    const a = Decimal.fromString("1234.56");
+    const b = Decimal.fromString("0.044");
+    expect(a.add(b).toString()).toBe("1234.604");
+  });
+  it("mul adds scales", () => {
+    expect(Decimal.fromString("2.50").mul(Decimal.fromString("0.13")).toString()).toBe("0.3250");
+  });
+  it("no float rounding on 0.1+0.2", () => {
+    expect(
+      Decimal.fromString("0.1").add(Decimal.fromString("0.2")).toString(),
+    ).toBe("0.3");
+  });
+});
+```
+
+- [ ] **Step 10: Run all VO tests**
+
+Run: `pnpm --filter @lapc506/invoice-core-core test value-objects`
+Expected: all green.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add packages/core/src/domain/value-objects/
+git commit -m "feat(domain): add UUID, ISODateTime, ISODate, Decimal value objects"
+```
+
+- [ ] **Step 12: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 7 — Base value objects" \
+  --label "phase/1,scope/domain,type/feat" \
+  --body "UUID (zod+brand), ISODateTime (RFC3339), ISODate (YYYY-MM-DD), Decimal (bigint+scale, float-safe)."
+```
+
+---
+
+## Task 8 — Domain VO: Money + Jurisdiction + CountryCode + UnitCode
+
+**Files:** `packages/core/src/domain/value-objects/{money,jurisdiction,country-code,unit-code}.ts` + tests.
+
+- [ ] **Step 1: Failing test `money.spec.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { Decimal } from "./decimal.js";
+import { InvalidMoney, Money } from "./money.js";
+
+describe("Money", () => {
+  it("creates with ISO 4217 currency", () => {
+    const m = Money.of(Decimal.fromString("100.00"), "CRC");
+    expect(m.currency).toBe("CRC");
+    expect(m.amount.toString()).toBe("100.00");
+  });
+  it("rejects unknown currency", () => {
+    expect(() => Money.of(Decimal.fromString("1"), "ZZZ")).toThrow(InvalidMoney);
+  });
+  it("refuses add across currencies", () => {
+    const crc = Money.of(Decimal.fromString("1"), "CRC");
+    const usd = Money.of(Decimal.fromString("1"), "USD");
+    expect(() => crc.add(usd)).toThrow(/currency mismatch/);
+  });
+});
+```
+
+- [ ] **Step 2: Implement `money.ts`**
+
+```ts
+import type { Decimal } from "./decimal.js";
+
+const ALLOWED = new Set(["CRC", "USD", "EUR", "MXN", "COP"]);
+
+export class Money {
+  private constructor(
+    public readonly amount: Decimal,
+    public readonly currency: string,
+  ) {}
+
+  static of(amount: Decimal, currency: string): Money {
+    if (!ALLOWED.has(currency)) throw new InvalidMoney(`currency ${currency}`);
+    return new Money(amount, currency);
+  }
+
+  add(other: Money): Money {
+    if (this.currency !== other.currency) {
+      throw new InvalidMoney(`currency mismatch: ${this.currency} vs ${other.currency}`);
+    }
+    return new Money(this.amount.add(other.amount), this.currency);
+  }
+
+  sub(other: Money): Money {
+    if (this.currency !== other.currency) {
+      throw new InvalidMoney(`currency mismatch: ${this.currency} vs ${other.currency}`);
+    }
+    return new Money(this.amount.sub(other.amount), this.currency);
+  }
+
+  toString(): string {
+    return `${this.amount.toString()} ${this.currency}`;
+  }
+}
+
+export class InvalidMoney extends Error {
+  constructor(msg: string) {
+    super(`Invalid money: ${msg}`);
+    this.name = "InvalidMoney";
+  }
+}
+```
+
+- [ ] **Step 3: Implement `jurisdiction.ts`**
+
+```ts
+import { z } from "zod";
+
+export const JURISDICTIONS = ["CR", "MX", "CO", "US", "GLOBAL"] as const;
+export type Jurisdiction = (typeof JURISDICTIONS)[number];
+
+const schema = z.enum(JURISDICTIONS);
+
+export const Jurisdiction = {
+  parse(input: unknown): Jurisdiction {
+    return schema.parse(input);
+  },
+};
+```
+
+- [ ] **Step 4: Implement `country-code.ts`** (ISO 3166-1 alpha-2)
+
+```ts
+import { z } from "zod";
+
+const schema = z.string().length(2).regex(/^[A-Z]{2}$/);
+
+export type CountryCode = string & { readonly __brand: "CountryCode" };
+
+export const CountryCode = {
+  parse(input: unknown): CountryCode {
+    return schema.parse(input) as CountryCode;
+  },
+};
+```
+
+- [ ] **Step 5: Implement `unit-code.ts`** (Hacienda CR catálogo — abbreviated to the commonly used codes for Fase 1)
+
+```ts
+import { z } from "zod";
+
+// Subset of Hacienda v4.4 unit catalog. Full catalog landed via ingester in Fase 3.
+export const UNIT_CODES = [
+  "Sp", "Unid", "kg", "g", "m", "cm", "mm", "l", "ml", "m2", "m3",
+  "h", "d", "kWh", "Al", "Alc", "I", "St", "Os",
+] as const;
+export type UnitCode = (typeof UNIT_CODES)[number];
+
+const schema = z.enum(UNIT_CODES);
+
+export const UnitCode = {
+  parse(input: unknown): UnitCode {
+    return schema.parse(input);
+  },
+};
+```
+
+- [ ] **Step 6: Tests for the other three VOs**
+
+Write `jurisdiction.spec.ts`, `country-code.spec.ts`, `unit-code.spec.ts` that each exercise valid + invalid inputs.
+
+- [ ] **Step 7: Run**
+
+Run: `pnpm --filter @lapc506/invoice-core-core test value-objects`
+Expected: all green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/core/src/domain/value-objects/
+git commit -m "feat(domain): add Money, Jurisdiction, CountryCode, UnitCode value objects"
+```
+
+- [ ] **Step 9: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 8 — Money + Jurisdiction + CountryCode + UnitCode" \
+  --label "phase/1,scope/domain,type/feat" \
+  --body "Money with ISO 4217 + cross-currency guard; enums for jurisdiction, country, unit (subset)."
+```
+
+---
+
+## Task 9 — Domain VO: PIIString
+
+**Files:** `packages/core/src/domain/value-objects/pii-string.ts` + test.
+
+- [ ] **Step 1: Failing test `pii-string.spec.ts`**
+
+```ts
+import { inspect } from "node:util";
+import { describe, expect, it } from "vitest";
+import { PIIString } from "./pii-string.js";
+
+describe("PIIString", () => {
+  it("toString redacts", () => {
+    expect(String(PIIString.from("Luis Andres"))).toBe("[REDACTED]");
+  });
+  it("toJSON redacts", () => {
+    expect(JSON.stringify({ name: PIIString.from("Luis") })).toBe('{"name":"[REDACTED]"}');
+  });
+  it("util.inspect redacts", () => {
+    expect(inspect(PIIString.from("secret"))).toContain("[REDACTED]");
+  });
+  it("unsafeReveal returns original", () => {
+    expect(PIIString.from("raw").unsafeReveal()).toBe("raw");
+  });
+});
+```
+
+- [ ] **Step 2: Implement `pii-string.ts`**
+
+```ts
+import { inspect } from "node:util";
+
+const VALUE = Symbol("pii.value");
+
+export class PIIString {
+  private readonly [VALUE]: string;
+
+  private constructor(v: string) {
+    this[VALUE] = v;
+  }
+
+  static from(v: string): PIIString {
+    return new PIIString(v);
+  }
+
+  unsafeReveal(): string {
+    return this[VALUE];
+  }
+
+  toString(): string {
+    return "[REDACTED]";
+  }
+
+  toJSON(): string {
+    return "[REDACTED]";
+  }
+
+  [inspect.custom](): string {
+    return "[REDACTED]";
+  }
+}
+```
+
+- [ ] **Step 3: Run**
+
+Run: `pnpm test pii-string`
+Expected: 4 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/domain/value-objects/pii-string.ts packages/core/src/domain/value-objects/pii-string.spec.ts
+git commit -m "feat(domain): add PIIString with redact-by-default serialization"
+```
+
+- [ ] **Step 5: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 9 — PIIString" \
+  --label "phase/1,scope/domain,type/feat,security/pii" \
+  --body "Safe-by-default PII wrapper — toString/toJSON/util.inspect all redact; unsafeReveal for adapter boundaries."
+```
+
+---
+
+## Task 10 — Domain VO: TaxId (CR + MX + CO)
+
+**Files:** `packages/core/src/domain/value-objects/tax-id.ts` + test.
+
+- [ ] **Step 1: Failing test `tax-id.spec.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { InvalidTaxId, TaxId } from "./tax-id.js";
+
+describe("TaxId", () => {
+  it("parses CR cédula física (9 digits)", () => {
+    const t = TaxId.parse({ country: "CR", kind: "FISICA", value: "112340567" });
+    expect(t.value).toBe("112340567");
+  });
+  it("parses CR cédula jurídica (10 digits)", () => {
+    const t = TaxId.parse({ country: "CR", kind: "JURIDICA", value: "3101123456" });
+    expect(t.kind).toBe("JURIDICA");
+  });
+  it("parses CR DIMEX (11-12 digits)", () => {
+    const t = TaxId.parse({ country: "CR", kind: "DIMEX", value: "112345678912" });
+    expect(t.kind).toBe("DIMEX");
+  });
+  it("parses MX RFC (12-13 alnum)", () => {
+    expect(TaxId.parse({ country: "MX", kind: "RFC", value: "VECJ880326XXX" }).value).toBe(
+      "VECJ880326XXX",
+    );
+  });
+  it("parses CO NIT (6-10 digits)", () => {
+    expect(TaxId.parse({ country: "CO", kind: "NIT", value: "1020304050" }).value).toBe(
+      "1020304050",
+    );
+  });
+  it("rejects CR cédula física with wrong length", () => {
+    expect(() => TaxId.parse({ country: "CR", kind: "FISICA", value: "12345" })).toThrow(
+      InvalidTaxId,
+    );
+  });
+  it("redacted() returns last 4 only", () => {
+    const t = TaxId.parse({ country: "CR", kind: "FISICA", value: "112340567" });
+    expect(t.redacted()).toBe("*****0567");
+  });
+  it("toString is redacted by default", () => {
+    const t = TaxId.parse({ country: "CR", kind: "FISICA", value: "112340567" });
+    expect(String(t)).toBe("*****0567");
+  });
+  it("unsafeReveal exposes raw value", () => {
+    const t = TaxId.parse({ country: "CR", kind: "FISICA", value: "112340567" });
+    expect(t.unsafeReveal()).toBe("112340567");
+  });
+});
+```
+
+- [ ] **Step 2: Implement `tax-id.ts`**
+
+```ts
+import { inspect } from "node:util";
+
+export type TaxIdKind =
+  | "FISICA"    // CR cédula física, 9 digits
+  | "JURIDICA"  // CR cédula jurídica, 10 digits
+  | "DIMEX"     // CR Documento de Identidad Migratorio, 11-12 digits
+  | "NITE"      // CR NITE (extranjeros), 10 digits
+  | "RFC"       // MX RFC, 12-13 alnum
+  | "NIT"       // CO NIT, 6-10 digits
+  | "PASSPORT"; // fallback
+
+export type TaxIdCountry = "CR" | "MX" | "CO";
+
+interface TaxIdInput {
+  country: TaxIdCountry;
+  kind: TaxIdKind;
+  value: string;
+}
+
+const RULES: Record<string, RegExp> = {
+  "CR:FISICA": /^\d{9}$/,
+  "CR:JURIDICA": /^\d{10}$/,
+  "CR:DIMEX": /^\d{11,12}$/,
+  "CR:NITE": /^\d{10}$/,
+  "MX:RFC": /^[A-ZÑ&]{3,4}\d{6}[A-Z0-9]{3}$/,
+  "CO:NIT": /^\d{6,10}$/,
+};
+
+export class TaxId {
+  private constructor(
+    public readonly country: TaxIdCountry,
+    public readonly kind: TaxIdKind,
+    private readonly _value: string,
+  ) {}
+
+  static parse(input: TaxIdInput): TaxId {
+    const key = `${input.country}:${input.kind}`;
+    const rule = RULES[key];
+    if (!rule) throw new InvalidTaxId(`unsupported ${key}`);
+    if (!rule.test(input.value)) throw new InvalidTaxId(`format ${key}: ${mask(input.value)}`);
+    return new TaxId(input.country, input.kind, input.value);
+  }
+
+  get value(): string {
+    return this._value;
+  }
+
+  redacted(): string {
+    const v = this._value;
+    return `${"*".repeat(Math.max(0, v.length - 4))}${v.slice(-4)}`;
+  }
+
+  unsafeReveal(): string {
+    return this._value;
+  }
+
+  toString(): string {
+    return this.redacted();
+  }
+
+  toJSON(): string {
+    return this.redacted();
+  }
+
+  [inspect.custom](): string {
+    return `TaxId(${this.country}:${this.kind}:${this.redacted()})`;
+  }
+}
+
+function mask(v: string): string {
+  return v.length <= 4 ? "****" : `${"*".repeat(v.length - 4)}${v.slice(-4)}`;
+}
+
+export class InvalidTaxId extends Error {
+  constructor(msg: string) {
+    super(`Invalid TaxId: ${msg}`);
+    this.name = "InvalidTaxId";
+  }
+}
+```
+
+- [ ] **Step 3: Run**
+
+Run: `pnpm test tax-id`
+Expected: 9 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/domain/value-objects/tax-id.ts packages/core/src/domain/value-objects/tax-id.spec.ts
+git commit -m "feat(domain): add TaxId VO for CR/MX/CO with redaction"
+```
+
+- [ ] **Step 5: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 10 — TaxId VO" \
+  --label "phase/1,scope/domain,type/feat,security/pii" \
+  --body "CR física/jurídica/DIMEX/NITE, MX RFC, CO NIT validators. Redaction by default; unsafeReveal for SDK adapters."
+```
+
+---
+
+## Task 11 — Domain VO: CABYS code + GTIN + ClaveNumerica
+
+**Files:** `packages/core/src/domain/value-objects/{cabys,gtin,clave-numerica}.ts` + tests.
+
+- [ ] **Step 1: Failing test `cabys.spec.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { CABYS, InvalidCabys } from "./cabys.js";
+
+describe("CABYS", () => {
+  it("accepts 13 digits", () => {
+    expect(CABYS.parse("1234567890123").value).toBe("1234567890123");
+  });
+  it("rejects 12 digits", () => {
+    expect(() => CABYS.parse("123456789012")).toThrow(InvalidCabys);
+  });
+  it("rejects non-digits", () => {
+    expect(() => CABYS.parse("12345678A0123")).toThrow(InvalidCabys);
+  });
+});
+```
+
+- [ ] **Step 2: Implement `cabys.ts`**
+
+Signature shape:
+
+```ts
+export class CABYS {
+  readonly value: string;
+  static parse(v: unknown): CABYS;
+}
+export class InvalidCabys extends Error {}
+```
+
+Implementation: 13-digit regex check. `toString()` returns raw code (public data).
+
+- [ ] **Step 3: Implement `gtin.ts`** with mod10 check and length ∈ {8,12,13,14}; `clave-numerica.ts` with 50-digit check + mod11 check digit at position 21 (per Hacienda CR spec). Tests for each cover valid + invalid + boundary.
+
+- [ ] **Step 4: Run**
+
+Run: `pnpm --filter @lapc506/invoice-core-core test -- cabys gtin clave-numerica`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/domain/value-objects/cabys.ts packages/core/src/domain/value-objects/gtin.ts packages/core/src/domain/value-objects/clave-numerica.ts packages/core/src/domain/value-objects/cabys.spec.ts packages/core/src/domain/value-objects/gtin.spec.ts packages/core/src/domain/value-objects/clave-numerica.spec.ts
+git commit -m "feat(domain): add CABYS, GTIN, ClaveNumerica value objects"
+```
+
+- [ ] **Step 6: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 11 — CABYS + GTIN + ClaveNumerica" \
+  --label "phase/1,scope/domain,type/feat,security/signature" \
+  --body "CABYS 13-digit validator, GTIN mod10 (8/12/13/14), ClaveNumerica 50-digit with mod11 check digit at pos 21."
+```
+
+---
+
+## Task 12 — Domain entity: Taxpayer + ForeignReceiver
+
+**Files:** `packages/core/src/domain/entities/{taxpayer,foreign-receiver}.ts` + tests.
+
+- [ ] **Step 1: Failing test `taxpayer.spec.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { TaxId } from "../value-objects/tax-id.js";
+import { PIIString } from "../value-objects/pii-string.js";
+import { Taxpayer } from "./taxpayer.js";
+
+describe("Taxpayer", () => {
+  it("builds a CR juridica taxpayer", () => {
+    const t = Taxpayer.of({
+      taxId: TaxId.parse({ country: "CR", kind: "JURIDICA", value: "3101123456" }),
+      legalName: PIIString.from("Vertivolatam S.A."),
+      activityCode: "722001",
+    });
+    expect(t.taxId.country).toBe("CR");
+  });
+  it("rejects empty activity code on CR issuer", () => {
+    expect(() =>
+      Taxpayer.of({
+        taxId: TaxId.parse({ country: "CR", kind: "JURIDICA", value: "3101123456" }),
+        legalName: PIIString.from("X"),
+        activityCode: "",
+      }),
+    ).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Implement `taxpayer.ts`**
+
+Signature shape:
+
+```ts
+export class Taxpayer {
+  readonly taxId: TaxId;
+  readonly legalName: PIIString;
+  readonly commercialName?: PIIString;
+  readonly activityCode: string;   // Hacienda economic activity code
+  readonly address?: TaxpayerAddress;
+  static of(input: TaxpayerInput): Taxpayer;
+}
+```
+
+CR issuers must have `activityCode` matching `^\d{6}$`. Non-CR taxpayers may have empty activityCode.
+
+- [ ] **Step 3: Implement `foreign-receiver.ts`** — receiver without local `TaxId`, uses `identification: { type, value, countryCode }`. For MX `RFC`, CO `NIT`, generic `PASSPORT`.
+
+- [ ] **Step 4: Run**
+
+Run: `pnpm test taxpayer foreign-receiver`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/domain/entities/taxpayer.ts packages/core/src/domain/entities/foreign-receiver.ts packages/core/src/domain/entities/taxpayer.spec.ts packages/core/src/domain/entities/foreign-receiver.spec.ts
+git commit -m "feat(domain): add Taxpayer + ForeignReceiver entities"
+```
+
+- [ ] **Step 6: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 12 — Taxpayer + ForeignReceiver" \
+  --label "phase/1,scope/domain,type/feat,security/pii" \
+  --body "Taxpayer aggregate with TaxId + PII-wrapped names + CR activity code. ForeignReceiver for non-local ids."
+```
+
+---
+
+## Task 13 — Domain entity: LineItem + TaxLine + TaxBreakdown
+
+**Files:** `packages/core/src/domain/entities/{line-item,tax-line,tax-breakdown}.ts` + tests.
+
+- [ ] **Step 1: Failing test `line-item.spec.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { Decimal } from "../value-objects/decimal.js";
+import { Money } from "../value-objects/money.js";
+import { CABYS } from "../value-objects/cabys.js";
+import { LineItem } from "./line-item.js";
+
+describe("LineItem", () => {
+  it("computes subtotal = qty * unitPrice", () => {
+    const li = LineItem.of({
+      sequenceNumber: 1,
+      cabysCode: CABYS.parse("1234567890123"),
+      description: "Cocoa beans, grade A",
+      quantity: Decimal.fromString("10"),
+      unitOfMeasure: "kg",
+      unitPrice: Money.of(Decimal.fromString("5000.00"), "CRC"),
+      taxes: [],
+    });
+    expect(li.subtotal().toString()).toBe("50000.00 CRC");
+  });
+});
+```
+
+- [ ] **Step 2: Implement `line-item.ts`**
+
+Signature shape:
+
+```ts
+export class LineItem {
+  readonly sequenceNumber: number;
+  readonly cabysCode: CABYS;
+  readonly productCode?: { type: ProductCodeType; code: string };
+  readonly description: string;
+  readonly quantity: Decimal;
+  readonly unitOfMeasure: UnitCode;
+  readonly unitPrice: Money;
+  readonly discount?: { rate: Decimal; amount: Money; reason?: string };
+  readonly taxes: TaxLine[];
+  readonly customsData?: CustomsLineData;
+  readonly traceabilityRef?: string;
+  subtotal(): Money;
+  totalWithTaxes(): Money;
+  static of(input: LineItemInput): LineItem;
+}
+```
+
+- [ ] **Step 3: Implement `tax-line.ts`** with code ∈ {01_IVA, 02_SELECT, 03_UNICO, 04_TIMBRE} + rate ∈ {0,1,2,4,13} + optional `exemption: { reason, legalCitation, percent }`.
+
+- [ ] **Step 4: Implement `tax-breakdown.ts`** — aggregator that groups line taxes by `(code, rate)` and yields `Money` totals.
+
+- [ ] **Step 5: Run**
+
+Run: `pnpm test line-item tax-line tax-breakdown`
+Expected: all green, ≥ 8 assertions across the three files.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/domain/entities/line-item.ts packages/core/src/domain/entities/tax-line.ts packages/core/src/domain/entities/tax-breakdown.ts packages/core/src/domain/entities/line-item.spec.ts packages/core/src/domain/entities/tax-line.spec.ts packages/core/src/domain/entities/tax-breakdown.spec.ts
+git commit -m "feat(domain): add LineItem + TaxLine + TaxBreakdown entities"
+```
+
+- [ ] **Step 7: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 13 — LineItem + TaxLine + TaxBreakdown" \
+  --label "phase/1,scope/domain,type/feat" \
+  --body "LineItem with optional customsData + traceabilityRef; TaxLine with CR IVA rates + exemption; TaxBreakdown aggregator."
+```
+
+---
+
+## Task 14 — Domain entity: DocumentSequence aggregate
+
+**Files:** `packages/core/src/domain/entities/document-sequence.ts` + test.
+
+- [ ] **Step 1: Failing test `document-sequence.spec.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { DocumentSequence } from "./document-sequence.js";
+
+describe("DocumentSequence", () => {
+  it("starts at 1 for a fresh (taxpayer, branch, terminal, docType) tuple", () => {
+    const seq = DocumentSequence.initial({ taxpayerId: "t1", branch: "001", terminal: "00001", docType: "INVOICE_CR" });
+    const next = seq.next();
+    expect(next.current).toBe(1n);
+  });
+  it("is monotonic (no gaps)", () => {
+    let seq = DocumentSequence.initial({ taxpayerId: "t1", branch: "001", terminal: "00001", docType: "INVOICE_CR" });
+    for (let i = 0; i < 5; i++) seq = seq.next();
+    expect(seq.current).toBe(5n);
+  });
+  it("rejects terminal with wrong length", () => {
+    expect(() => DocumentSequence.initial({ taxpayerId: "t1", branch: "001", terminal: "1", docType: "INVOICE_CR" })).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Implement `document-sequence.ts`**
+
+Signature shape:
+
+```ts
+export class DocumentSequence {
+  readonly taxpayerId: string;
+  readonly branch: string;      // 3 digits
+  readonly terminal: string;    // 5 digits
+  readonly docType: DocumentType;
+  readonly current: bigint;     // last consumed
+  next(): DocumentSequence;
+  format(): string;             // 20-digit Hacienda consecutivo
+  static initial(input: SeqInput): DocumentSequence;
+}
+```
+
+The persistence layer (Task 39) enforces gap-free advance via advisory lock.
+
+- [ ] **Step 3: Run**
+
+Run: `pnpm test document-sequence`
+Expected: 3 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/domain/entities/document-sequence.ts packages/core/src/domain/entities/document-sequence.spec.ts
+git commit -m "feat(domain): add DocumentSequence aggregate (branch/terminal/docType)"
+```
+
+- [ ] **Step 5: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 14 — DocumentSequence aggregate" \
+  --label "phase/1,scope/domain,type/feat,security/signature" \
+  --body "Per (taxpayer, branch, terminal, docType) monotonic consecutivo; format() yields 20-digit Hacienda field."
+```
+
+---
+
+## Task 15 — Domain entity: Document base + Invoice + Ticket
+
+**Files:** `packages/core/src/domain/entities/{document-base,invoice,ticket}.ts` + tests.
+
+- [ ] **Step 1: Failing test `invoice.spec.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { Invoice } from "./invoice.js";
+// … import test factories from fixtures
+import { anInvoiceInput } from "../__fixtures__/invoice-fixtures.js";
+
+describe("Invoice (INVOICE_CR)", () => {
+  it("is created with status=DRAFT", () => {
+    const inv = Invoice.create(anInvoiceInput());
+    expect(inv.status).toBe("DRAFT");
+  });
+  it("computes grand total from line items + taxes", () => {
+    const inv = Invoice.create(anInvoiceInput());
+    expect(inv.totals.grandTotal.currency).toBe("CRC");
+  });
+  it("rejects condicionVenta CREDITO without plazoCredito", () => {
+    expect(() => Invoice.create(anInvoiceInput({ condicionVenta: "CREDITO" }))).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Implement `document-base.ts`**
+
+Abstract base shared by all subtypes. Holds `id`, `type`, `status`, `issuer`, `receiver`, `issuedAt`, `fiscalPeriod`, `lineItems`, `taxBreakdown`, `totals`, `relatedDocuments`, `xmlBlob`, `claveNumerica?`, `acknowledgment?`, `auditTrail`. Constructor validates required fields and delegates discriminator to subclass.
+
+- [ ] **Step 3: Implement `invoice.ts`** (`type = "INVOICE_CR"`, adds `condicionVenta: "CONTADO"|"CREDITO"|"CONSIGNACION"|"APARTADO"|"ARRENDAMIENTO_OPCION_COMPRA"|"ARRENDAMIENTO_FUNCION_FINANCIERA"|"COBRO_TERCEROS"|"SERVICIOS_ESTADO_CREDITO"|"PAGO_SERVICIOS_INSTITUCION_ESTADO"|"OTROS"`, `medioPago: MedioPago[]`, `plazoCredito?: number`).
+
+- [ ] **Step 4: Implement `ticket.ts`** (`type = "TICKET_CR"`, receiver optional, smaller schema).
+
+- [ ] **Step 5: Run**
+
+Run: `pnpm test invoice ticket document-base`
+Expected: ≥ 6 assertions green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/domain/entities/document-base.ts packages/core/src/domain/entities/invoice.ts packages/core/src/domain/entities/ticket.ts packages/core/src/domain/entities/invoice.spec.ts packages/core/src/domain/entities/ticket.spec.ts packages/core/src/domain/entities/__fixtures__/
+git commit -m "feat(domain): add Document base + Invoice + Ticket subtypes"
+```
+
+- [ ] **Step 7: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 15 — Document base + Invoice + Ticket" \
+  --label "phase/1,scope/domain,type/feat" \
+  --body "Abstract Document base + Invoice (01) + Ticket (04) subtypes with totals computation."
+```
+
+---
+
+## Task 16 — Domain entity: CreditNote + DebitNote
+
+**Files:** `packages/core/src/domain/entities/{credit-note,debit-note}.ts` + tests.
+
+- [ ] **Step 1: Failing test `credit-note.spec.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { CreditNote } from "./credit-note.js";
+import { aCreditNoteInput } from "../__fixtures__/credit-note-fixtures.js";
+
+describe("CreditNote (CREDIT_NOTE_CR)", () => {
+  it("requires at least one relatedDocument", () => {
+    expect(() => CreditNote.create(aCreditNoteInput({ relatedDocuments: [] }))).toThrow();
+  });
+  it("relatedDocument must be of type INVOICE_CR or TICKET_CR", () => {
+    expect(() =>
+      CreditNote.create(aCreditNoteInput({
+        relatedDocuments: [{ type: "CREDIT_NOTE_CR", claveNumerica: "X".repeat(50), issuedAt: "2026-04-15T00:00:00Z" }],
+      })),
+    ).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Implement `credit-note.ts`** (`type = "CREDIT_NOTE_CR"`, requires `relatedDocuments[0].type ∈ {INVOICE_CR, TICKET_CR, EXPORT_INVOICE_CR}`).
+
+- [ ] **Step 3: Implement `debit-note.ts`** (`type = "DEBIT_NOTE_CR"`, same related-doc rule).
+
+- [ ] **Step 4: Run**
+
+Run: `pnpm test credit-note debit-note`
+Expected: ≥ 4 assertions green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/domain/entities/credit-note.ts packages/core/src/domain/entities/debit-note.ts packages/core/src/domain/entities/credit-note.spec.ts packages/core/src/domain/entities/debit-note.spec.ts packages/core/src/domain/entities/__fixtures__/credit-note-fixtures.ts
+git commit -m "feat(domain): add CreditNote + DebitNote subtypes with referential rules"
+```
+
+- [ ] **Step 6: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 16 — CreditNote + DebitNote" \
+  --label "phase/1,scope/domain,type/feat" \
+  --body "NC/ND (02/03) with referential integrity to source INVOICE_CR/TICKET_CR/EXPORT_INVOICE_CR."
+```
+
+---
+
+## Task 17 — Domain entity: PurchaseInvoice (tipo 08) + ExportInvoice (tipo 09 skeleton)
+
+**Files:** `packages/core/src/domain/entities/{purchase-invoice,export-invoice}.ts` + tests.
+
+- [ ] **Step 1: Failing test `purchase-invoice.spec.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { PurchaseInvoice } from "./purchase-invoice.js";
+import { aPurchaseInvoiceInput } from "../__fixtures__/purchase-invoice-fixtures.js";
+
+describe("PurchaseInvoice (PURCHASE_INVOICE_CR, tipo 08)", () => {
+  it("requires providerNotRegistered block", () => {
+    expect(() => PurchaseInvoice.create(aPurchaseInvoiceInput({ providerNotRegistered: undefined }))).toThrow();
+  });
+  it("accepts provider with idType=00_NINGUNO (grower with no id)", () => {
+    const pi = PurchaseInvoice.create(aPurchaseInvoiceInput({
+      providerNotRegistered: { idType: "00_NINGUNO", name: "Grower X" },
+    }));
+    expect(pi.type).toBe("PURCHASE_INVOICE_CR");
+  });
+});
+```
+
+- [ ] **Step 2: Implement `purchase-invoice.ts`** — required `providerNotRegistered: { idType: "05_EXTRANJERO" | "00_NINGUNO"; name; identifier? }`. Issuer must be inscrito.
+
+- [ ] **Step 3: Implement `export-invoice.ts`** (`type = "EXPORT_INVOICE_CR"`, adds `incoterms?`, receiver must be `ForeignReceiver`, currency not restricted to CRC). Skeleton; deeper validation lands in Fase 4.
+
+- [ ] **Step 4: Run**
+
+Run: `pnpm test purchase-invoice export-invoice`
+Expected: ≥ 4 assertions green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/domain/entities/purchase-invoice.ts packages/core/src/domain/entities/export-invoice.ts packages/core/src/domain/entities/purchase-invoice.spec.ts packages/core/src/domain/entities/export-invoice.spec.ts packages/core/src/domain/entities/__fixtures__/purchase-invoice-fixtures.ts
+git commit -m "feat(domain): add PurchaseInvoice (08) + ExportInvoice (09 skeleton)"
+```
+
+- [ ] **Step 6: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 17 — PurchaseInvoice 08 + ExportInvoice 09" \
+  --label "phase/1,scope/domain,type/feat" \
+  --body "Factura-compra tipo 08 for non-registered providers (Vertivolatam growers). ExportInvoice tipo 09 skeleton with ForeignReceiver."
+```
+
+---
+
+## Task 18 — Domain entity: ReceiverMessage + WithholdingCertificate stub + DonationReceipt stub
+
+**Files:** `packages/core/src/domain/entities/{receiver-message,withholding-certificate,donation-receipt}.ts` + tests.
+
+- [ ] **Step 1: Failing test `receiver-message.spec.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { ReceiverMessage } from "./receiver-message.js";
+import { aReceiverMessageInput } from "../__fixtures__/receiver-message-fixtures.js";
+
+describe("ReceiverMessage", () => {
+  it("supports messageType=1 (accept)", () => {
+    const r = ReceiverMessage.create(aReceiverMessageInput({ messageType: 1 }));
+    expect(r.messageType).toBe(1);
+  });
+  it("supports messageType=3 (reject) requires rejectionReason", () => {
+    expect(() => ReceiverMessage.create(aReceiverMessageInput({ messageType: 3, rejectionReason: undefined }))).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Implement `receiver-message.ts`** — fields: `sourceClaveNumerica`, `messageType: 1|2|3`, `rejectionReason?`, `totalImpuesto`, `totalFactura`, `condicionImpuesto?`.
+
+- [ ] **Step 3: Implement `withholding-certificate.ts`** — stub that constructs but returns `status: "DRAFT"` and throws `NotImplementedInFase1` on `.sign()` call. Jurisdiction-aware: `WITHHOLDING_MX` or `WITHHOLDING_CO`.
+
+- [ ] **Step 4: Implement `donation-receipt.ts`** — stub: allows construction with `kind ∈ {CASH, IN_KIND, SERVICE}` + `donatario` + `donor`, but `.finalize()` throws `NotImplementedInFase1` (full flow lands in Fase 2).
+
+- [ ] **Step 5: Run**
+
+Run: `pnpm test receiver-message withholding-certificate donation-receipt`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/domain/entities/receiver-message.ts packages/core/src/domain/entities/withholding-certificate.ts packages/core/src/domain/entities/donation-receipt.ts packages/core/src/domain/entities/receiver-message.spec.ts packages/core/src/domain/entities/withholding-certificate.spec.ts packages/core/src/domain/entities/donation-receipt.spec.ts
+git commit -m "feat(domain): add ReceiverMessage + Withholding/Donation stubs"
+```
+
+- [ ] **Step 7: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 18 — ReceiverMessage + Withholding/Donation stubs" \
+  --label "phase/1,scope/domain,type/feat" \
+  --body "ReceiverMessage full; WithholdingCertificate + DonationReceipt stubs throw NotImplementedInFase1 for .sign()/.finalize()."
+```
+
+---
+
+## Task 19 — Domain entity: Dispute aggregate
+
+**Files:** `packages/core/src/domain/entities/dispute.ts` + test.
+
+- [ ] **Step 1: Failing test `dispute.spec.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { Dispute } from "./dispute.js";
+
+describe("Dispute", () => {
+  it("opens from an inbound document", () => {
+    const d = Dispute.open({ inboundDocumentId: "doc-1", reason: "duplicate_line_item", reportedBy: "user-42" });
+    expect(d.status).toBe("OPEN");
+  });
+  it("resolves with a resolution note", () => {
+    const d = Dispute.open({ inboundDocumentId: "doc-1", reason: "wrong_amount", reportedBy: "user-42" });
+    const r = d.resolve({ resolvedBy: "user-1", note: "supplier reissued via NC" });
+    expect(r.status).toBe("RESOLVED");
+  });
+  it("rejects resolve() when already RESOLVED", () => {
+    const d = Dispute.open({ inboundDocumentId: "doc-1", reason: "x", reportedBy: "u" }).resolve({ resolvedBy: "u", note: "ok" });
+    expect(() => d.resolve({ resolvedBy: "u", note: "again" })).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Implement `dispute.ts`**
+
+Signature shape:
+
+```ts
+export type DisputeStatus = "OPEN" | "ESCALATED" | "RESOLVED" | "REJECTED";
+export class Dispute {
+  readonly id: string;
+  readonly inboundDocumentId: string;
+  readonly reason: string;
+  readonly status: DisputeStatus;
+  readonly reportedBy: string;
+  readonly resolvedBy?: string;
+  readonly note?: string;
+  static open(input): Dispute;
+  escalate(by: string): Dispute;
+  resolve(input): Dispute;
+  reject(input): Dispute;
+}
+```
+
+Immutable — each transition returns a new instance.
+
+- [ ] **Step 3: Run**
+
+Run: `pnpm test dispute`
+Expected: 3 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/domain/entities/dispute.ts packages/core/src/domain/entities/dispute.spec.ts
+git commit -m "feat(domain): add Dispute aggregate with OPEN→ESCALATED→RESOLVED/REJECTED states"
+```
+
+- [ ] **Step 5: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 19 — Dispute aggregate" \
+  --label "phase/1,scope/domain,type/feat" \
+  --body "Dispute states (OPEN/ESCALATED/RESOLVED/REJECTED) for AduaNext inbound reconciliation gaps."
+```
+
+---
+
+## Task 20 — Domain services: state machine + totals + clave builder
+
+**Files:** `packages/core/src/domain/services/{state-machine,totals-calculator,clave-builder}.ts` + tests.
+
+- [ ] **Step 1: Failing test `state-machine.spec.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { InvalidDocumentStateTransition, transition } from "./state-machine.js";
+
+describe("state-machine", () => {
+  it("DRAFT → SIGNED allowed", () => {
+    expect(transition("DRAFT", "SIGNED")).toBe("SIGNED");
+  });
+  it("ACCEPTED → SIGNED rejected", () => {
+    expect(() => transition("ACCEPTED", "SIGNED")).toThrow(InvalidDocumentStateTransition);
+  });
+  it("REJECTED is terminal", () => {
+    expect(() => transition("REJECTED", "CANCELLED")).toThrow(InvalidDocumentStateTransition);
+  });
+});
+```
+
+- [ ] **Step 2: Implement `state-machine.ts`** per spec §4.3.
+
+- [ ] **Step 3: Implement `totals-calculator.ts`** — pure function `computeTotals(lineItems: LineItem[]): DocumentTotals` returning `{ subtotal, totalDiscounts, totalTaxes, totalExempt, grandTotal }`.
+
+- [ ] **Step 4: Implement `clave-builder.ts`** — 50-digit composition: `país(3) + día(2) + mes(2) + año(2) + taxId(12, left-padded) + sucursal(3) + terminal(5) + tipoDoc(2) + consecutivo(10) + situación(1) + código(8) + check(1)` with mod11 check at last pos.
+
+- [ ] **Step 5: Run**
+
+Run: `pnpm test state-machine totals-calculator clave-builder`
+Expected: ≥ 8 assertions green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/domain/services/state-machine.ts packages/core/src/domain/services/totals-calculator.ts packages/core/src/domain/services/clave-builder.ts packages/core/src/domain/services/state-machine.spec.ts packages/core/src/domain/services/totals-calculator.spec.ts packages/core/src/domain/services/clave-builder.spec.ts
+git commit -m "feat(domain): add state machine + totals calculator + clave builder services"
+```
+
+- [ ] **Step 7: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 20 — Domain services (state/totals/clave)" \
+  --label "phase/1,scope/domain,type/feat,security/signature" \
+  --body "State machine per §4.3; totals aggregator; clave-numerica builder with mod11 check digit."
+```
+
+---
+
+## Task 21 — Domain events + typed errors barrel
+
+**Files:** `packages/core/src/domain/events/*.ts` + `packages/core/src/domain/errors.ts` + `packages/core/src/domain/index.ts`.
+
+- [ ] **Step 1: Failing test `events.spec.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { DocumentIssued, DocumentAccepted, DocumentRejected, ReceiverMessageReceived, DocumentReconciled } from "./index.js";
+
+describe("domain events", () => {
+  it("DocumentIssued carries id + clave + issuer + timestamp", () => {
+    const e = DocumentIssued.of({ documentId: "d1", claveNumerica: "0".repeat(50), issuerTaxId: "3101123456", at: "2026-04-16T00:00:00Z" });
+    expect(e.type).toBe("DocumentIssued");
+    expect(e.version).toBe(1);
+  });
+  it("events never serialize raw PII", () => {
+    const e = DocumentRejected.of({ documentId: "d1", reasonCode: "INVALID_XML", at: "2026-04-16T00:00:00Z" });
+    expect(JSON.stringify(e)).not.toContain("cédula");
+  });
+});
+```
+
+- [ ] **Step 2: Implement event classes** under `packages/core/src/domain/events/` — one file per event with static `of()` factory + readonly fields. Cover: `DocumentIssued`, `DocumentAccepted`, `DocumentRejected`, `DocumentCancelled`, `InboundReceived`, `InboundValidated`, `ReceiverMessageSubmitted` (aka `ReceiverMessageReceived` alias), `ReconciliationCompleted` (aka `DocumentReconciled`), `AuthorityUnavailable`.
+
+- [ ] **Step 3: Implement `errors.ts`** with typed errors from spec §4 + barrel in `domain/index.ts` re-exporting all VOs + entities + services + events + errors.
+
+- [ ] **Step 4: Run**
+
+Run: `pnpm test events`
+Expected: all events green; PII-leak assertion passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/domain/events/ packages/core/src/domain/errors.ts packages/core/src/domain/index.ts
+git commit -m "feat(domain): add domain events + typed errors + public barrel"
+```
+
+- [ ] **Step 6: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 21 — Domain events + errors barrel" \
+  --label "phase/1,scope/domain,type/feat,security/pii" \
+  --body "9 domain events (Issued/Accepted/Rejected/Cancelled/InboundReceived/InboundValidated/ReceiverMessageSubmitted/ReconciliationCompleted/AuthorityUnavailable) + typed errors, zero PII in payloads."
+```
+
+---
+
+
+
+## Task 22 — Application ports: persistence group (DocumentRepository, TaxpayerRepository, SequenceRepository, CABYSRepository)
+
+**Files:** `packages/core/src/app/ports/{document-repository-port,taxpayer-repository-port,sequence-repository-port,cabys-repository-port}.ts` + contract tests.
+
+- [ ] **Step 1: Failing test `document-repository-port.contract.ts`**
+
+Defines a shared test suite that any adapter (Postgres, in-memory) must satisfy:
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { DocumentRepositoryPort } from "./document-repository-port.js";
+
+export function documentRepositoryContract(factory: () => DocumentRepositoryPort) {
+  describe("DocumentRepositoryPort contract", () => {
+    it("save + findById round-trips", async () => {
+      const repo = factory();
+      // … build a canonical Invoice fixture …
+      // await repo.save(inv);
+      // expect((await repo.findById(inv.id))?.id).toBe(inv.id);
+    });
+  });
+}
+```
+
+Plus an in-memory stub implementation that must pass the contract.
+
+- [ ] **Step 2: Define port interfaces**
+
+Signature shapes:
+
+```ts
+export interface DocumentRepositoryPort {
+  save(doc: Document): Promise<void>;
+  findById(id: string): Promise<Document | null>;
+  findByClaveNumerica(clave: string): Promise<Document | null>;
+  list(q: DocumentQuery): AsyncIterable<Document>;
+  updateStatus(id: string, to: DocumentStatus, ack?: Acknowledgment): Promise<void>;
+}
+export interface TaxpayerRepositoryPort {
+  save(t: Taxpayer): Promise<void>;
+  findByTaxId(taxId: TaxId): Promise<Taxpayer | null>;
+}
+export interface SequenceRepositoryPort {
+  nextFor(key: SequenceKey): Promise<DocumentSequence>;  // MUST be gap-free
+}
+export interface CABYSRepositoryPort {
+  lookup(code: string): Promise<CabysEntry | null>;
+  search(term: string, limit: number): Promise<CabysEntry[]>;
+  upsertBatch(entries: CabysEntry[]): Promise<number>;
+}
+```
+
+- [ ] **Step 3: In-memory stub + contract run**
+
+Run: `pnpm test document-repository-port`
+Expected: in-memory stub passes the shared contract.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/app/ports/document-repository-port.ts packages/core/src/app/ports/taxpayer-repository-port.ts packages/core/src/app/ports/sequence-repository-port.ts packages/core/src/app/ports/cabys-repository-port.ts packages/core/src/app/ports/__contract__/
+git commit -m "feat(app): add persistence ports + shared contract tests"
+```
+
+- [ ] **Step 5: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 22 — Persistence ports" \
+  --label "phase/1,scope/app,type/feat" \
+  --body "DocumentRepository / TaxpayerRepository / SequenceRepository / CABYSRepository ports + portable contract suites."
+```
+
+---
+
+## Task 23 — Application ports: authority + inbound group (TaxAuthorityPort, ReceiverMessagePort, InboundDocumentGatewayPort, SignatureVerifierPort)
+
+**Files:** `packages/core/src/app/ports/{tax-authority-port,receiver-message-port,inbound-document-gateway-port,signature-verifier-port}.ts` + contract stubs.
+
+- [ ] **Step 1: Failing test `tax-authority-port.contract.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { TaxAuthorityPort } from "./tax-authority-port.js";
+
+export function taxAuthorityContract(factory: () => TaxAuthorityPort) {
+  describe("TaxAuthorityPort contract", () => {
+    it("submit returns a SubmissionAck with traceable id", async () => {
+      // fake adapter returns synthetic ack
+    });
+    it("queryStatus maps authority codes to DocumentStatus", async () => {});
+  });
+}
+```
+
+- [ ] **Step 2: Define port interfaces**
+
+Signature shapes:
+
+```ts
+export interface TaxAuthorityPort {
+  submit(signedXml: Buffer, ctx: SubmitCtx): Promise<SubmissionAck>;
+  queryStatus(claveNumerica: string, ctx: AuthorityCtx): Promise<AuthorityStatus>;
+  health(): Promise<AuthorityHealth>;
+  jurisdiction: Jurisdiction;
+}
+export interface ReceiverMessagePort {
+  submit(msg: ReceiverMessage, signed: Buffer, ctx: SubmitCtx): Promise<SubmissionAck>;
+}
+export interface InboundDocumentGatewayPort {
+  subscribe(handler: (raw: InboundRawDocument) => Promise<void>): Promise<Unsubscribe>;
+  pollOnce(ctx: PollCtx): Promise<InboundRawDocument[]>;
+}
+export interface SignatureVerifierPort {
+  verify(xml: Buffer, policy: SignaturePolicy): Promise<VerificationResult>;
+}
+```
+
+- [ ] **Step 3: Fake-based contract tests**
+
+Write a fake that implements each port with in-memory lookups — contracts must pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/app/ports/tax-authority-port.ts packages/core/src/app/ports/receiver-message-port.ts packages/core/src/app/ports/inbound-document-gateway-port.ts packages/core/src/app/ports/signature-verifier-port.ts packages/core/src/app/ports/__contract__/
+git commit -m "feat(app): add authority + inbound ports with contract stubs"
+```
+
+- [ ] **Step 5: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 23 — Authority + inbound ports" \
+  --label "phase/1,scope/app,type/feat" \
+  --body "TaxAuthorityPort / ReceiverMessagePort / InboundDocumentGatewayPort / SignatureVerifierPort with contract suites."
+```
+
+---
+
+## Task 24 — Application ports: infrastructure group (CertificateVault, EventPublisher, Clock, IdGenerator, RetryQueue, PIIRedactor, ReconciliationEngine)
+
+**Files:** `packages/core/src/app/ports/{certificate-vault-port,event-bus-port,clock-port,idempotency-port,queue-port,pii-redactor-port,reconciliation-port}.ts`.
+
+- [ ] **Step 1: Failing test `certificate-vault-port.contract.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { CertificateVaultPort } from "./certificate-vault-port.js";
+
+export function certificateVaultContract(factory: () => CertificateVaultPort) {
+  describe("CertificateVaultPort contract", () => {
+    it("loadP12 returns a Disposable buffer cleared on dispose", async () => {});
+    it("getExpiry returns a future ISO date for valid certs", async () => {});
+  });
+}
+```
+
+- [ ] **Step 2: Define port interfaces**
+
+Signature shapes:
+
+```ts
+export interface CertificateVaultPort {
+  loadP12(taxpayerId: string): Promise<DisposableP12>;
+  getExpiry(taxpayerId: string): Promise<ISODate>;
+  watchExpiring(threshold: Duration): AsyncIterable<CertificateExpiringEvent>;
+}
+export interface EventPublisherPort {
+  publish<E extends DomainEvent>(event: E, ctx: PublishCtx): Promise<void>;
+}
+export interface ClockPort { now(): ISODateTime; date(): ISODate; }
+export interface IdGeneratorPort { uuid(): UUID; }
+export interface RetryQueuePort {
+  enqueue(job: SubmissionJob): Promise<string>;
+  subscribe(handler: JobHandler): Promise<Unsubscribe>;
+  depth(): Promise<number>;
+}
+export interface PIIRedactorPort { redact<T>(obj: T): T; }
+export interface ReconciliationEnginePort {
+  reconcile(inbound: Document, candidates: PurchaseOrder[]): Promise<ReconciliationResult>;
+}
+```
+
+- [ ] **Step 3: In-memory + fake-clock adapters**
+
+Provide fakes that pass contracts. Commit them to `packages/core/src/app/ports/__fakes__/`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/app/ports/
+git commit -m "feat(app): add infrastructure ports + in-memory fakes"
+```
+
+- [ ] **Step 5: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 24 — Infrastructure ports" \
+  --label "phase/1,scope/app,type/feat,security/credentials" \
+  --body "CertificateVault (Disposable), EventPublisher, Clock, IdGenerator, RetryQueue, PIIRedactor, ReconciliationEngine."
+```
+
+---
+
+## Task 25 — Application ports: stub group (DonationAuthorization, Appraisal, CustomsData, FilingDataExport, OCR, AccountingSink)
+
+**Files:** `packages/core/src/app/ports/{donation-authorization-port,appraisal-port,customs-data-port,filing-data-export-port,ocr-port,accounting-sink-port}.ts`.
+
+- [ ] **Step 1: Failing test `stubs.spec.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { UnimplementedInFase1 } from "../../domain/errors.js";
+import { donationAuthorizationStub, appraisalStub, customsDataStub, filingDataExportStub, ocrStub, accountingSinkStub } from "./__stubs__/index.js";
+
+describe("Fase 1 stubs throw UnimplementedInFase1", () => {
+  it("DonationAuthorization.isAuthorized throws", async () => {
+    await expect(donationAuthorizationStub().isAuthorized("3101123456")).rejects.toThrow(UnimplementedInFase1);
+  });
+  // … one assertion per stub
+});
+```
+
+- [ ] **Step 2: Define port interfaces + stubs**
+
+Signature shapes (minimal):
+
+```ts
+export interface DonationAuthorizationPort { isAuthorized(taxId: string): Promise<AuthorizationStatus>; }
+export interface AppraisalPort { attach(ref: URI, docId: string): Promise<AppraisalRef>; }
+export interface CustomsDataPort { fetchDUA(duaNumber: string): Promise<CustomsLineData>; }
+export interface FilingDataExportPort { exportD101Casillas(period: FiscalPeriod): Promise<D101Data>; /* + D104, D103 */ }
+export interface OCRPort { extract(pdf: Buffer): Promise<OCRResult>; }
+export interface AccountingSinkPort { push(doc: Document): Promise<SinkReceipt>; }
+```
+
+Each stub throws `UnimplementedInFase1` with a message pointing to the Fase that lands the real adapter.
+
+- [ ] **Step 3: Run**
+
+Run: `pnpm test stubs`
+Expected: 6 stubs throw correctly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/app/ports/donation-authorization-port.ts packages/core/src/app/ports/appraisal-port.ts packages/core/src/app/ports/customs-data-port.ts packages/core/src/app/ports/filing-data-export-port.ts packages/core/src/app/ports/ocr-port.ts packages/core/src/app/ports/accounting-sink-port.ts packages/core/src/app/ports/__stubs__/
+git commit -m "feat(app): add Fase 2-5 port interfaces + UnimplementedInFase1 stubs"
+```
+
+- [ ] **Step 5: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 25 — Deferred port stubs" \
+  --label "phase/1,scope/app,type/feat" \
+  --body "6 deferred ports as interfaces + UnimplementedInFase1 stubs so proto RPCs can wire to placeholders and Fase 2-5 adapters swap in without breaking changes."
+```
+
+---
+
+## Task 26 — Use case: IssueInvoice (TDD)
+
+**Files:** `packages/core/src/app/commands/issue-invoice.ts` + test.
+
+- [ ] **Step 1: Failing test `issue-invoice.spec.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { IssueInvoice } from "./issue-invoice.js";
+import { testComposition } from "../__fixtures__/composition.js";
+
+describe("IssueInvoice", () => {
+  it("persists as SIGNED and enqueues submission", async () => {
+    const deps = testComposition();
+    const ack = await new IssueInvoice(deps).execute(/* request */);
+    expect(ack.status).toBe("QUEUED");
+    expect(deps.queue.depth()).resolves.toBe(1);
+  });
+  it("emits DocumentIssued event", async () => {
+    const deps = testComposition();
+    await new IssueInvoice(deps).execute(/* request */);
+    expect(deps.eventPublisher.published.map(e => e.type)).toContain("DocumentIssued");
+  });
+  it("is idempotent on the same idempotencyKey", async () => {
+    const deps = testComposition();
+    const uc = new IssueInvoice(deps);
+    const a = await uc.execute({ idempotencyKey: "k1" /* … */ });
+    const b = await uc.execute({ idempotencyKey: "k1" /* … */ });
+    expect(a.claveNumerica).toBe(b.claveNumerica);
+    expect(deps.queue.depth()).resolves.toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Implement `issue-invoice.ts`**
+
+Flow:
+
+1. Lookup idempotency → short-circuit if hit.
+2. Load Taxpayer via `TaxpayerRepositoryPort.findByTaxId(request.issuerTaxId)`.
+3. `SequenceRepositoryPort.nextFor` → consecutivo.
+4. `clave-builder` → 50-digit key.
+5. Build domain `Invoice` via `Invoice.create(...)`.
+6. `DocumentRepositoryPort.save` with status=SIGNED (signing done inside adapter next step — Fase 1 simplification: status moves to SIGNED after building XML).
+7. `RetryQueuePort.enqueue(job)`.
+8. `EventPublisherPort.publish(DocumentIssued)`.
+9. Return `DocumentAck { claveNumerica, status: QUEUED }`.
+
+- [ ] **Step 3: Run**
+
+Run: `pnpm test issue-invoice`
+Expected: 3 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/app/commands/issue-invoice.ts packages/core/src/app/commands/issue-invoice.spec.ts
+git commit -m "feat(app): add IssueInvoice use case (idempotent, event-emitting)"
+```
+
+- [ ] **Step 5: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 26 — IssueInvoice use case" \
+  --label "phase/1,scope/app,type/feat,priority/p0" \
+  --body "Primary emission use case: lookup taxpayer → seq → clave → build domain → persist SIGNED → enqueue → emit DocumentIssued. Idempotent."
+```
+
+---
+
+## Task 27 — Use case: IssueCreditNote + IssueDebitNote + CancelDocument
+
+**Files:** `packages/core/src/app/commands/{issue-credit-note,issue-debit-note,cancel-document}.ts` + tests.
+
+- [ ] **Step 1: Failing tests**
+
+```ts
+// issue-credit-note.spec.ts
+it("requires source document to exist and be in ACCEPTED state", async () => {
+  // deps with no matching source → throws SourceDocumentNotFound
+});
+it("inherits issuer from source invoice", async () => { /* … */ });
+// cancel-document.spec.ts
+it("issues a CreditNote referencing the source and transitions source to CANCELLED-on-accept", async () => { /* … */ });
+```
+
+- [ ] **Step 2: Implement `issue-credit-note.ts`** — pattern identical to IssueInvoice but validates source doc + references it.
+
+- [ ] **Step 3: Implement `issue-debit-note.ts`** — same shape.
+
+- [ ] **Step 4: Implement `cancel-document.ts`** — orchestrates `IssueCreditNote` with full-amount negative lines; only transitions source to `CANCELLED` after NC acceptance (listener on `DocumentAccepted`).
+
+- [ ] **Step 5: Run**
+
+Run: `pnpm test issue-credit-note issue-debit-note cancel-document`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/app/commands/issue-credit-note.ts packages/core/src/app/commands/issue-debit-note.ts packages/core/src/app/commands/cancel-document.ts packages/core/src/app/commands/issue-credit-note.spec.ts packages/core/src/app/commands/issue-debit-note.spec.ts packages/core/src/app/commands/cancel-document.spec.ts
+git commit -m "feat(app): add IssueCreditNote / IssueDebitNote / CancelDocument"
+```
+
+- [ ] **Step 7: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 27 — Credit/Debit Note + Cancel" \
+  --label "phase/1,scope/app,type/feat" \
+  --body "NC/ND emission + CancelDocument orchestrator (issues NC + listens for Accepted → transitions source to CANCELLED)."
+```
+
+---
+
+## Task 28 — Use case: IssueTicket + IssuePurchaseInvoice (tipo 08) + IssueExportInvoice (tipo 09 skeleton)
+
+**Files:** `packages/core/src/app/commands/{issue-ticket,issue-purchase-invoice,issue-export-invoice}.ts` + tests.
+
+- [ ] **Step 1: Failing tests**
+
+```ts
+// issue-ticket.spec.ts — smaller: no receiver required
+it("accepts request with no receiver", async () => { /* … */ });
+// issue-purchase-invoice.spec.ts
+it("issuer must be inscrito; provider block carries idType=05_EXTRANJERO", async () => { /* … */ });
+// issue-export-invoice.spec.ts
+it("receiver must be ForeignReceiver; currency may be USD", async () => { /* … */ });
+```
+
+- [ ] **Step 2: Implement the three use cases**
+
+Each reuses the `IssueInvoice` skeleton from Task 26 with subtype-specific validation + domain factory (`Ticket.create`, `PurchaseInvoice.create`, `ExportInvoice.create`).
+
+- [ ] **Step 3: Run**
+
+Run: `pnpm test issue-ticket issue-purchase-invoice issue-export-invoice`
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/app/commands/issue-ticket.ts packages/core/src/app/commands/issue-purchase-invoice.ts packages/core/src/app/commands/issue-export-invoice.ts packages/core/src/app/commands/issue-ticket.spec.ts packages/core/src/app/commands/issue-purchase-invoice.spec.ts packages/core/src/app/commands/issue-export-invoice.spec.ts
+git commit -m "feat(app): add IssueTicket + IssuePurchaseInvoice (08) + IssueExportInvoice (09)"
+```
+
+- [ ] **Step 5: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 28 — Ticket + PurchaseInvoice + ExportInvoice" \
+  --label "phase/1,scope/app,type/feat" \
+  --body "Three subtype use cases: Ticket (04), PurchaseInvoice (08 — Vertivolatam growers), ExportInvoice (09 skeleton)."
+```
+
+---
+
+## Task 29 — Use case: ReceiveIncomingDocument + AcknowledgeReceipt (Mensaje Receptor)
+
+**Files:** `packages/core/src/app/commands/{receive-incoming-document,respond-to-receiver-message}.ts` + tests.
+
+- [ ] **Step 1: Failing test `receive-incoming-document.spec.ts`**
+
+```ts
+it("validates signature before persisting", async () => {
+  const deps = testComposition({ signatureVerifier: fakeFailingVerifier() });
+  await expect(new ReceiveIncomingDocument(deps).execute(/* raw */)).rejects.toThrow("SignatureInvalid");
+});
+it("persists + emits InboundReceived + InboundValidated", async () => { /* … */ });
+```
+
+- [ ] **Step 2: Implement `receive-incoming-document.ts`**
+
+Flow:
+1. Parse XML → domain snapshot.
+2. `SignatureVerifierPort.verify` — fail fast if invalid.
+3. Persist via `DocumentRepositoryPort` (new doc with status=ACCEPTED, direction=INBOUND).
+4. Emit `InboundReceived`, then `InboundValidated`.
+
+- [ ] **Step 3: Implement `respond-to-receiver-message.ts`**
+
+Flow:
+1. Fetch inbound doc.
+2. Build `ReceiverMessage` with `messageType ∈ {1,2,3}`.
+3. Sign + submit via `ReceiverMessagePort`.
+4. Emit `ReceiverMessageSubmitted`.
+
+- [ ] **Step 4: Run**
+
+Run: `pnpm test receive-incoming-document respond-to-receiver-message`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/app/commands/receive-incoming-document.ts packages/core/src/app/commands/respond-to-receiver-message.ts packages/core/src/app/commands/receive-incoming-document.spec.ts packages/core/src/app/commands/respond-to-receiver-message.spec.ts
+git commit -m "feat(app): add ReceiveIncomingDocument + RespondToReceiverMessage"
+```
+
+- [ ] **Step 6: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 29 — Inbound + Mensaje Receptor" \
+  --label "phase/1,scope/app,type/feat,priority/p0" \
+  --body "Inbound validation (signature-first) + Mensaje Receptor emission per CR v4.4."
+```
+
+---
+
+## Task 30 — Use case: ReconcileDocument (Fase 1 scaffold)
+
+**Files:** `packages/core/src/app/commands/reconcile-inbound.ts` + test.
+
+- [ ] **Step 1: Failing test `reconcile-inbound.spec.ts`**
+
+```ts
+it("matches 1:1 on claveNumerica + expected PO", async () => { /* … */ });
+it("returns UNMATCHED when no candidate fits", async () => { /* … */ });
+it("emits DocumentReconciled on match", async () => { /* … */ });
+```
+
+- [ ] **Step 2: Implement `reconcile-inbound.ts`**
+
+Delegates heavy lifting to `ReconciliationEnginePort.reconcile`. Fase 1 implementation: the engine is in-memory, matches on `(claveNumerica, grandTotal, issuerTaxId)` within tolerance; Fase 3 adds AduaNext-specific DUA matching.
+
+- [ ] **Step 3: Run**
+
+Run: `pnpm test reconcile-inbound`
+Expected: 3 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/app/commands/reconcile-inbound.ts packages/core/src/app/commands/reconcile-inbound.spec.ts
+git commit -m "feat(app): add ReconcileDocument use case (Fase 1 in-memory engine)"
+```
+
+- [ ] **Step 5: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 30 — ReconcileDocument" \
+  --label "phase/1,scope/app,type/feat" \
+  --body "Fase 1 in-memory reconciliation (clave + total + issuer). Fase 3 adds DUA matching for AduaNext."
+```
+
+---
+
+## Task 31 — Middleware chain (tracing / auth / idempotency / metrics / PII redaction) + composition barrel
+
+**Files:** `packages/core/src/app/middleware/*.ts` + `packages/core/src/app/index.ts`.
+
+- [ ] **Step 1: Failing test `middleware.spec.ts`**
+
+```ts
+it("tracing middleware starts and ends a span per invocation", async () => { /* … */ });
+it("idempotency short-circuits duplicate keys", async () => { /* … */ });
+it("PII redaction runs before logs emit", async () => { /* … */ });
+it("auth denies missing bearer on REST path", async () => { /* … */ });
+it("metrics increments invoice_issued_total on success", async () => { /* … */ });
+```
+
+- [ ] **Step 2: Implement five middleware modules**
+
+Each is a small higher-order function `(next) => (req, ctx) => Promise<Resp>` composable via `compose(mw1, mw2, ..., handler)`.
+
+- [ ] **Step 3: Implement `app/index.ts` barrel**
+
+Re-exports commands + queries + ports + middleware for consumption by `packages/server`.
+
+- [ ] **Step 4: Run**
+
+Run: `pnpm test middleware`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/app/middleware/ packages/core/src/app/index.ts
+git commit -m "feat(app): add middleware chain + app barrel"
+```
+
+- [ ] **Step 6: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 31 — Middleware chain" \
+  --label "phase/1,scope/app,type/feat,security/pii,priority/p0" \
+  --body "Tracing + auth + idempotency + metrics + PII redaction; composition barrel so server layer consumes one import."
+```
+
+---
+
+
+## Task 32 — Proto codegen pipeline (buf) + generated `packages/proto`
+
+**Files:** `proto/buf.yaml`, `proto/buf.gen.yaml`, `proto/invoice_core/v1/*.proto`, `packages/proto/{package.json,tsconfig.json}`.
+
+- [ ] **Step 1: Write `proto/buf.yaml`**
+
+```yaml
+version: v2
+lint:
+  use: [DEFAULT]
+breaking:
+  use: [WIRE_JSON]
+```
+
+- [ ] **Step 2: Write `proto/buf.gen.yaml`**
+
+```yaml
+version: v2
+plugins:
+  - local: protoc-gen-es
+    out: packages/proto/src/generated
+    opt: [target=ts]
+  - local: protoc-gen-connect-es
+    out: packages/proto/src/generated
+    opt: [target=ts]
+```
+
+- [ ] **Step 3: Author proto files** per spec §6 with `common.proto`, `document.proto`, `admin.proto`, `inbox.proto`, `reporting.proto`, `health.proto`. Keep `reporting.proto` fully declared even though implementation returns `UNIMPLEMENTED` for D-101/D-104/D-103.
+
+- [ ] **Step 4: Run codegen**
+
+```bash
+pnpm install @bufbuild/protobuf @bufbuild/protoc-gen-es @connectrpc/connect @connectrpc/protoc-gen-connect-es
+pnpm proto:lint
+pnpm proto:gen
+```
+
+Expected: `packages/proto/src/generated/invoice_core/v1/*.ts` produced; no lint errors.
+
+- [ ] **Step 5: Contract test** that generated `DocumentAck` has fields `claveNumerica`, `status`, `documentId`.
+
+```ts
+import { DocumentAck } from "@lapc506/invoice-core-proto/invoice_core/v1/common_pb.js";
+it("DocumentAck shape", () => {
+  const a = new DocumentAck({ claveNumerica: "0".repeat(50), status: "QUEUED", documentId: "d1" });
+  expect(a.claveNumerica).toHaveLength(50);
+});
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add proto/ packages/proto/
+git commit -m "feat(proto): add buf codegen pipeline + v1 services"
+```
+
+- [ ] **Step 7: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 32 — Proto codegen pipeline" \
+  --label "phase/1,scope/proto,type/feat" \
+  --body "buf lint + breaking + codegen to packages/proto. Admin/Inbox/Reporting/Health services declared; Reporting D-101/D-104/D-103 return UNIMPLEMENTED in Fase 1."
+```
+
+---
+
+## Task 33 — HaciendaCRAdapter: builders + signer (wraps `@dojocoding/hacienda-sdk`)
+
+**Files:** `packages/adapter-hacienda-cr/src/{index,hacienda-cr-adapter,signer}.ts` + `builders/*` + tests using SDK sandbox fixtures.
+
+- [ ] **Step 1: Failing test `hacienda-cr-adapter.spec.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { HaciendaCRAdapter } from "./hacienda-cr-adapter.js";
+import { inMemoryVault, sampleInvoice } from "./__fixtures__/index.js";
+
+describe("HaciendaCRAdapter", () => {
+  it("submit() signs XML then delegates to SDK client", async () => {
+    const sdkClient = fakeSdkClient({ submit: async () => ({ clave: "0".repeat(50), status: "recibido" }) });
+    const adapter = new HaciendaCRAdapter({ sdkClient, vault: inMemoryVault(), metrics: fakeMetrics() });
+    const ack = await adapter.submit(await buildSignedXml(sampleInvoice()), { taxpayerId: "t1" });
+    expect(ack.authorityId).toBe("0".repeat(50));
+  });
+  it("maps SDK TimeoutError to AuthorityTimeout domain error", async () => { /* … */ });
+});
+```
+
+- [ ] **Step 2: Implement adapter**
+
+Signature shape:
+
+```ts
+export class HaciendaCRAdapter implements TaxAuthorityPort, ReceiverMessagePort {
+  readonly jurisdiction = "CR";
+  constructor(private deps: { sdkClient: HaciendaSdkClient; vault: CertificateVaultPort; metrics: AdapterMetrics; clock: ClockPort });
+  async submit(xml: Buffer, ctx: SubmitCtx): Promise<SubmissionAck>;
+  async queryStatus(clave: string, ctx: AuthorityCtx): Promise<AuthorityStatus>;
+  async health(): Promise<AuthorityHealth>;
+}
+```
+
+`submit` uses `builders/*` to translate domain fixtures → SDK builder calls; `signer.ts` wraps SDK signing using `vault.loadP12` within a try/finally that disposes the buffer.
+
+- [ ] **Step 3: Implement 7 builders** (`invoice-builder`, `ticket-builder`, `credit-note-builder`, `debit-note-builder`, `purchase-invoice-builder`, `export-invoice-builder`, `receiver-message-builder`) each with a unit test that maps a minimal domain fixture → expected SDK builder output shape.
+
+- [ ] **Step 4: Implement `errors.ts`** mapping SDK errors → domain errors (`AuthorityTimeout`, `AuthorityRejected`, `SignatureInvalid`, `CertificateExpired`).
+
+- [ ] **Step 5: Run**
+
+Run: `pnpm --filter @lapc506/invoice-core-adapter-hacienda-cr test`
+Expected: builders + adapter green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/adapter-hacienda-cr/
+git commit -m "feat(hacienda-cr): wrap @dojocoding/hacienda-sdk as TaxAuthorityPort + ReceiverMessagePort"
+```
+
+- [ ] **Step 7: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 33 — HaciendaCRAdapter (builders + signer)" \
+  --label "phase/1,scope/hacienda-cr,type/feat,security/credentials,priority/p0" \
+  --body "Wraps @dojocoding/hacienda-sdk. 7 builders (01/02/03/04/08/09/MR). SDK errors → domain errors. Signing via CertificateVault Disposable."
+```
+
+---
+
+## Task 34 — HaciendaCRAdapter: submitter + status-poller + metrics
+
+**Files:** `packages/adapter-hacienda-cr/src/{submitter,status-poller,metrics}.ts` + tests.
+
+- [ ] **Step 1: Failing test `status-poller.spec.ts`**
+
+```ts
+it("polls with exponential backoff until ACCEPTED", async () => { /* uses fake-timers */ });
+it("bubbles AuthorityTimeout after maxAttempts", async () => { /* … */ });
+it("emits invoice_authority_latency_seconds histogram observation", async () => { /* … */ });
+```
+
+- [ ] **Step 2: Implement submitter + poller**
+
+Signature shape:
+
+```ts
+export class Submitter {
+  constructor(private sdk: HaciendaSdkClient, private metrics: AdapterMetrics);
+  submit(xml: Buffer, ctx: SubmitCtx): Promise<RawAck>;
+}
+export class StatusPoller {
+  constructor(private sdk: HaciendaSdkClient, private clock: ClockPort, private opts: PollOpts);
+  pollUntilFinal(clave: string, ctx: AuthorityCtx): Promise<AuthorityStatus>;
+}
+```
+
+Backoff: 1s, 2s, 4s, 8s, 15s, 30s, 60s (cap). Timeout 5 min total.
+
+- [ ] **Step 3: Implement `metrics.ts`** — Prometheus histogram `invoice_authority_latency_seconds{authority,operation}` + counter `invoice_authority_errors_total{authority,code}` using `prom-client`.
+
+- [ ] **Step 4: Run**
+
+Run: `pnpm --filter @lapc506/invoice-core-adapter-hacienda-cr test submitter status-poller metrics`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/adapter-hacienda-cr/src/submitter.ts packages/adapter-hacienda-cr/src/status-poller.ts packages/adapter-hacienda-cr/src/metrics.ts packages/adapter-hacienda-cr/src/submitter.spec.ts packages/adapter-hacienda-cr/src/status-poller.spec.ts packages/adapter-hacienda-cr/src/metrics.spec.ts
+git commit -m "feat(hacienda-cr): add Submitter + StatusPoller + Prometheus metrics"
+```
+
+- [ ] **Step 6: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 34 — Submitter + StatusPoller + metrics" \
+  --label "phase/1,scope/hacienda-cr,type/feat" \
+  --body "Submission with exponential backoff, terminal-state polling, Prometheus histogram + counters per §11."
+```
+
+---
+
+## Task 35 — PostgreSQL schema via Drizzle + migrations
+
+**Files:** `packages/adapter-postgres/src/schema/*.ts`, `packages/adapter-postgres/drizzle.config.ts`, `packages/adapter-postgres/migrations/0001_init.sql`.
+
+- [ ] **Step 1: Failing test `schema-shape.spec.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { documents, documentSequences, taxpayers, inboundDocuments, disputes, cabys, idempotency, outbox } from "./schema/index.js";
+
+describe("Postgres schema", () => {
+  it("documents table has clave_numerica unique index", () => { /* introspect table config */ });
+  it("document_sequences has unique (taxpayer_id, branch, terminal, doc_type)", () => { /* … */ });
+  it("idempotency has 24h TTL partition", () => { /* … */ });
+});
+```
+
+- [ ] **Step 2: Implement schema files** (one per aggregate, barrel `schema/index.ts`):
+
+Signature shape for `documents`:
+
+```ts
+export const documents = pgTable("documents", {
+  id: uuid("id").primaryKey(),
+  taxpayerId: varchar("taxpayer_id", { length: 36 }).notNull(),
+  type: varchar("type", { length: 32 }).notNull(),
+  status: varchar("status", { length: 16 }).notNull(),
+  claveNumerica: varchar("clave_numerica", { length: 50 }),
+  payload: jsonb("payload").notNull(),     // domain JSON snapshot
+  xmlBlobUri: text("xml_blob_uri"),
+  issuedAt: timestamp("issued_at", { withTimezone: true }).notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});
+// + index("documents_clave_uk").on(documents.claveNumerica)
+```
+
+Other tables: `document_sequences`, `taxpayers`, `inbound_documents`, `disputes`, `cabys`, `idempotency`, `outbox` (for event publish durability).
+
+- [ ] **Step 3: Generate + author `0001_init.sql`** via `drizzle-kit generate`.
+
+- [ ] **Step 4: Docker-based migration smoke**
+
+```bash
+docker compose -f docker-compose.dev.yml up -d postgres
+pnpm --filter @lapc506/invoice-core-adapter-postgres exec drizzle-kit push
+```
+
+Expected: tables created; re-run is idempotent.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/adapter-postgres/src/schema/ packages/adapter-postgres/drizzle.config.ts packages/adapter-postgres/migrations/
+git commit -m "feat(postgres): add Drizzle schema + initial migration"
+```
+
+- [ ] **Step 6: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 35 — Postgres schema + migrations" \
+  --label "phase/1,scope/postgres,type/feat,security/pii" \
+  --body "8 tables: documents + document_sequences + taxpayers + inbound_documents + disputes + cabys + idempotency + outbox. JSONB payload + claveNumerica unique index."
+```
+
+---
+
+## Task 36 — DocumentRepositoryPg + TaxpayerRepositoryPg
+
+**Files:** `packages/adapter-postgres/src/repositories/{document-repository,taxpayer-repository}.ts` + integration tests against real Postgres.
+
+- [ ] **Step 1: Failing test `document-repository.integration.spec.ts`**
+
+Uses `documentRepositoryContract` from Task 22:
+
+```ts
+import { documentRepositoryContract } from "@lapc506/invoice-core-core/app/ports/__contract__/document-repository-port.js";
+import { DocumentRepositoryPg } from "./document-repository.js";
+import { withPg } from "../__fixtures__/pg.js";
+
+documentRepositoryContract(() => new DocumentRepositoryPg(withPg()));
+```
+
+- [ ] **Step 2: Implement `DocumentRepositoryPg`** — `save` upsert by `id`, `findById`, `findByClaveNumerica`, `list` with async iteration via cursor, `updateStatus` touches `status` + appends to `audit_trail` array column.
+
+- [ ] **Step 3: Implement `TaxpayerRepositoryPg`** — `save` + `findByTaxId(country, kind, value)` index lookup.
+
+- [ ] **Step 4: Run**
+
+Run: `pnpm --filter @lapc506/invoice-core-adapter-postgres test:integration`
+Expected: contract suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/adapter-postgres/src/repositories/document-repository.ts packages/adapter-postgres/src/repositories/taxpayer-repository.ts packages/adapter-postgres/src/repositories/document-repository.integration.spec.ts packages/adapter-postgres/src/repositories/taxpayer-repository.integration.spec.ts
+git commit -m "feat(postgres): add DocumentRepositoryPg + TaxpayerRepositoryPg"
+```
+
+- [ ] **Step 6: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 36 — DocumentRepositoryPg + TaxpayerRepositoryPg" \
+  --label "phase/1,scope/postgres,type/feat,priority/p0" \
+  --body "Postgres-backed implementations passing the shared port contract suite."
+```
+
+---
+
+## Task 37 — SequenceRepositoryPg with gap-free advisory-lock + CABYS CSV ingester
+
+**Files:** `packages/adapter-postgres/src/repositories/{sequence-repository,cabys-repository}.ts`, `packages/adapter-postgres/src/cabys-csv-ingester.ts` + tests.
+
+- [ ] **Step 1: Failing test `sequence-repository.integration.spec.ts`**
+
+```ts
+it("100 concurrent nextFor() on the same key produce 1..100 gap-free", async () => {
+  const repo = new SequenceRepositoryPg(pg);
+  const out = await Promise.all(Array.from({ length: 100 }, () => repo.nextFor(key)));
+  const nums = out.map(s => Number(s.current)).sort((a, b) => a - b);
+  expect(nums).toEqual(Array.from({ length: 100 }, (_, i) => i + 1));
+});
+```
+
+- [ ] **Step 2: Implement `SequenceRepositoryPg`**
+
+Uses `pg_advisory_xact_lock(hashtext($key))` inside a transaction that reads `current`, increments, writes back, commits. Hashing is deterministic per `(taxpayerId, branch, terminal, docType)`.
+
+- [ ] **Step 3: Implement `CABYSRepositoryPg`** — `lookup` by exact code, `search` by trigram (`pg_trgm`), `upsertBatch` via `INSERT ... ON CONFLICT DO UPDATE`.
+
+- [ ] **Step 4: Implement `cabys-csv-ingester.ts`**
+
+Reads Hacienda CABYS CSV feed, streams rows through `zod` validation, batches 500 rows into `CABYSRepositoryPg.upsertBatch`.
+
+Test: with a 100-row fixture, ingester produces 100 rows; re-run produces 0 new rows.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/adapter-postgres/src/repositories/sequence-repository.ts packages/adapter-postgres/src/repositories/cabys-repository.ts packages/adapter-postgres/src/cabys-csv-ingester.ts packages/adapter-postgres/src/repositories/sequence-repository.integration.spec.ts packages/adapter-postgres/src/repositories/cabys-repository.integration.spec.ts packages/adapter-postgres/src/cabys-csv-ingester.spec.ts
+git commit -m "feat(postgres): add gap-free SequenceRepositoryPg + CABYS CSV ingester"
+```
+
+- [ ] **Step 6: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 37 — SequenceRepositoryPg + CABYS" \
+  --label "phase/1,scope/postgres,type/feat,security/signature,priority/p0" \
+  --body "Advisory-lock gap-free consecutivo (100-parallel test). CABYSRepositoryPg + trigram search + weekly CSV ingester."
+```
+
+---
+
+## Task 38 — CertificateVault: Vault + sealed-secrets + local-FS fallback
+
+**Files:** `packages/adapter-vault/src/{local-fs-vault,vault-credential-vault,sealed-secrets-loader,certificate-expiry-monitor}.ts` + tests.
+
+- [ ] **Step 1: Failing test `local-fs-vault.spec.ts`**
+
+```ts
+it("loadP12 returns a Disposable buffer cleared on dispose", async () => {
+  const v = new LocalFsVault({ rootDir: tmpDir });
+  const d = await v.loadP12("t1");
+  expect(d.buffer.byteLength).toBeGreaterThan(0);
+  d[Symbol.dispose]();
+  expect(d.buffer.byteLength).toBe(0);
+});
+it("getExpiry parses PKCS#12 validTo correctly", async () => { /* … */ });
+```
+
+- [ ] **Step 2: Implement `local-fs-vault.ts`**
+
+Signature shape:
+
+```ts
+export class LocalFsVault implements CertificateVaultPort {
+  constructor(private opts: { rootDir: string; passwordEnv?: string });
+  async loadP12(taxpayerId: string): Promise<DisposableP12> { /* reads ${rootDir}/${taxpayerId}.p12 */ }
+  async getExpiry(taxpayerId: string): Promise<ISODate>;
+  watchExpiring(threshold: Duration): AsyncIterable<CertificateExpiringEvent>;
+}
+```
+
+`DisposableP12` implements `Symbol.dispose` and zero-fills the buffer.
+
+- [ ] **Step 3: Implement `vault-credential-vault.ts`** using Vault KV v2 HTTP API (renew token every 50% of TTL).
+
+- [ ] **Step 4: Implement `sealed-secrets-loader.ts`** — reads projected volume at `/etc/invoice-core/certs/${taxpayerId}.p12` + password at `/etc/invoice-core/certs/${taxpayerId}.pass`.
+
+- [ ] **Step 5: Implement `certificate-expiry-monitor.ts`** — scheduled job that emits `CertificateExpiringEvent` at 30/14/7/1 days before expiry.
+
+- [ ] **Step 6: Run**
+
+Run: `pnpm --filter @lapc506/invoice-core-adapter-vault test`
+Expected: all green; each vault passes the shared `certificateVaultContract`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/adapter-vault/
+git commit -m "feat(vault): add CertificateVault adapters (Vault + sealed-secrets + local-FS)"
+```
+
+- [ ] **Step 8: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 38 — CertificateVault" \
+  --label "phase/1,scope/vault,type/feat,security/credentials,priority/p0" \
+  --body "Three vault backends all passing CertificateVaultPort contract. Disposable buffers + expiry monitor emitting 30/14/7/1-day events."
+```
+
+---
+
+## Task 39 — XAdES-EPES SignatureVerifier (xadesjs) + policy check
+
+**Files:** `packages/adapter-signature/src/{xades-epes-verifier,xades-policy-check}.ts` + golden XML fixtures.
+
+- [ ] **Step 1: Failing test `xades-epes-verifier.spec.ts`**
+
+```ts
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { XadesEpesVerifier } from "./xades-epes-verifier.js";
+
+describe("XadesEpesVerifier", () => {
+  const validXml = readFileSync("src/__fixtures__/valid-signed.xml");
+  const tampered = readFileSync("src/__fixtures__/tampered-signed.xml");
+
+  it("accepts Hacienda CR signed XML with valid XAdES-EPES signature and policy hash", async () => {
+    const r = await new XadesEpesVerifier().verify(validXml, { policyHash: "Ohixl6upD6av8N7pEvDABhEL6hM=" });
+    expect(r.valid).toBe(true);
+  });
+  it("rejects tampered XML", async () => {
+    const r = await new XadesEpesVerifier().verify(tampered, { policyHash: "Ohixl6upD6av8N7pEvDABhEL6hM=" });
+    expect(r.valid).toBe(false);
+  });
+  it("rejects XAdES-BES (wrong form)", async () => { /* … */ });
+});
+```
+
+- [ ] **Step 2: Implement `xades-epes-verifier.ts`**
+
+Uses `xadesjs` + `xmldsig-js`; verifies: canonicalization, digest, signature value, certificate chain against Hacienda CR root CA, policy identifier matches `Ohixl6upD6av8N7pEvDABhEL6hM=` with SHA-1.
+
+- [ ] **Step 3: Implement `xades-policy-check.ts`** — pluggable check so future jurisdictions can swap policy.
+
+- [ ] **Step 4: Run**
+
+Run: `pnpm --filter @lapc506/invoice-core-adapter-signature test`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/adapter-signature/
+git commit -m "feat(signature): add XAdES-EPES verifier with CR policy hash"
+```
+
+- [ ] **Step 6: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 39 — XAdES-EPES verifier" \
+  --label "phase/1,scope/signature,type/feat,security/signature,priority/p0" \
+  --body "Verifies canonicalization + digest + signature value + certificate chain + policy hash Ohixl6upD6av8N7pEvDABhEL6hM="
+```
+
+---
+
+## Task 40 — BullMQ RetryQueue + opossum circuit breaker
+
+**Files:** `packages/adapter-queue/src/{bullmq-queue,submission-worker,status-poll-worker,circuit-breaker,retry-policy}.ts` + tests.
+
+- [ ] **Step 1: Failing test `bullmq-queue.spec.ts`**
+
+```ts
+it("enqueue returns a jobId and depth increments", async () => { /* uses redis-memory-server */ });
+it("subscribe dispatches jobs to the handler in FIFO order", async () => { /* … */ });
+```
+
+- [ ] **Step 2: Implement `bullmq-queue.ts`** implementing `RetryQueuePort` — thin wrapper around `Queue` + `Worker` from BullMQ. Jobs carry `{ documentId, claveNumerica, attempt, createdAt }`.
+
+- [ ] **Step 3: Implement `retry-policy.ts`** — exponential backoff `1s, 5s, 30s, 2m, 10m, 1h, 6h, 24h` with jitter; permanent failure after 24h.
+
+- [ ] **Step 4: Implement `circuit-breaker.ts`** — `opossum` wrapper per `jurisdiction`. Opens on 50% failure rate over last 20 calls, half-open after 30s, resets on 3 consecutive successes. Emits `invoice_circuit_breaker_state{authority}` gauge updates.
+
+- [ ] **Step 5: Implement `submission-worker.ts`** — pulls from queue, calls `TaxAuthorityPort.submit`, persists status, enqueues status-poll job on success. Circuit-breaker-wrapped.
+
+- [ ] **Step 6: Implement `status-poll-worker.ts`** — runs StatusPoller from Task 34.
+
+- [ ] **Step 7: Run**
+
+Run: `pnpm --filter @lapc506/invoice-core-adapter-queue test`
+Expected: all green; 10-job burst test shows depth monotonic.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/adapter-queue/
+git commit -m "feat(queue): add BullMQ RetryQueue + submission/status-poll workers + opossum circuit breaker"
+```
+
+- [ ] **Step 9: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 40 — RetryQueue + workers + circuit breaker" \
+  --label "phase/1,scope/queue,type/feat,priority/p0" \
+  --body "BullMQ queue with submission + status-poll workers. opossum circuit breaker per authority with 50%/20/30s policy. Emits invoice_queue_depth + invoice_circuit_breaker_state metrics."
+```
+
+---
+
+## Task 41 — Observability: pino logger + OTel tracer + Prometheus metrics
+
+**Files:** `packages/adapter-otel/src/{tracer,metrics,logger}.ts` + tests.
+
+- [ ] **Step 1: Failing test `logger.spec.ts`**
+
+```ts
+it("redacts PII keys by path", () => {
+  const log = createLogger({ level: "info", redactPaths: ["issuer.taxId", "receiver.taxId", "lineItems[*].description"] });
+  const out = captureLogs(() => log.info({ issuer: { taxId: "112340567" } }, "emission"));
+  expect(out).toContain('"taxId":"[Redacted]"');
+  expect(out).not.toContain("112340567");
+});
+```
+
+- [ ] **Step 2: Implement `logger.ts`**
+
+pino logger configured with `redact: { paths, remove: false, censor: "[Redacted]" }` and `formatters.level` for JSON output. Export a `createLogger` factory + default instance.
+
+- [ ] **Step 3: Implement `tracer.ts`**
+
+OTel SDK bootstrap: `@opentelemetry/sdk-node` with OTLP HTTP exporter → env `OTEL_EXPORTER_OTLP_ENDPOINT`. Auto-instrumentation: `@opentelemetry/auto-instrumentations-node`. Custom attributes: `invoice.jurisdiction`, `invoice.doc_type`.
+
+- [ ] **Step 4: Implement `metrics.ts`**
+
+`prom-client` default registry + histograms/counters per spec §11. Expose `register` for `/metrics` scraping.
+
+- [ ] **Step 5: Run**
+
+Run: `pnpm --filter @lapc506/invoice-core-adapter-otel test`
+Expected: logger redaction + tracer smoke + metrics introspection green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/adapter-otel/
+git commit -m "feat(otel): add pino logger + OTel tracer + Prometheus metrics"
+```
+
+- [ ] **Step 7: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 41 — Observability (pino + OTel + prom-client)" \
+  --label "phase/1,scope/otel,type/feat,security/pii,priority/p0" \
+  --body "pino with redact paths per PII policy; OTel SDK → OTLP; prom-client registry exposing §11 metrics."
+```
+
+---
+
+## Task 42 — InboundDocumentGateway: Hacienda webhook + polling worker
+
+**Files:** `packages/adapter-inbound/src/{hacienda-webhook-route,hacienda-polling-worker,inbound-parser}.ts` + tests.
+
+- [ ] **Step 1: Failing test `inbound-parser.spec.ts`**
+
+```ts
+it("parses Hacienda inbound envelope → InboundRawDocument", async () => {
+  const raw = readFileSync("src/__fixtures__/hacienda-inbound.json", "utf8");
+  const parsed = parseHaciendaInbound(raw);
+  expect(parsed.source).toBe("hacienda-cr");
+  expect(parsed.xmlBlob.byteLength).toBeGreaterThan(0);
+});
+```
+
+- [ ] **Step 2: Implement `inbound-parser.ts`** — decodes base64 XML payload, parses envelope metadata.
+
+- [ ] **Step 3: Implement `hacienda-webhook-route.ts`** — Fastify route factory that HMAC-verifies the request, parses, calls `ReceiveIncomingDocument` use case. Returns 202 on success, 400 on bad signature.
+
+- [ ] **Step 4: Implement `hacienda-polling-worker.ts`** — runs every 5 min, fetches recent inbound via SDK, dedupes against `inbound_documents.clave_numerica`, calls use case.
+
+- [ ] **Step 5: Run**
+
+Run: `pnpm --filter @lapc506/invoice-core-adapter-inbound test`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/adapter-inbound/
+git commit -m "feat(inbound): add Hacienda webhook route + polling worker + parser"
+```
+
+- [ ] **Step 7: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 42 — InboundDocumentGateway" \
+  --label "phase/1,scope/inbound,type/feat,security/signature" \
+  --body "Webhook (HMAC-verified) + 5-min polling worker. Dedupe on clave_numerica. Feeds ReceiveIncomingDocument use case."
+```
+
+---
+
+
+## Task 43 — gRPC server bootstrap (`:50061`) + DI composition root
+
+**Files:** `packages/server/src/grpc/server.ts`, `packages/server/src/composition/{wire,config,mode}.ts`.
+
+- [ ] **Step 1: Failing test `grpc-bootstrap.spec.ts`**
+
+```ts
+it("boots on 127.0.0.1:<ephemeral> and answers Health.Check", async () => {
+  const app = await buildTestApp({ grpcPort: 0 });
+  const res = await new HealthClient(app.channel).check({});
+  expect(res.status).toBe("SERVING");
+  await app.close();
+});
+```
+
+- [ ] **Step 2: Implement `composition/config.ts`** — zod-validated env loader: `GRPC_PORT`, `REST_PORT`, `METRICS_PORT`, `DATABASE_URL`, `REDIS_URL`, `VAULT_*`, `HACIENDA_*`, `DEPLOYMENT_MODE`, `LOG_LEVEL`, `OTEL_EXPORTER_OTLP_ENDPOINT`.
+
+- [ ] **Step 3: Implement `composition/wire.ts`** — DI composition root returning `{ useCases, queries, workers, closer }`. Wires: Postgres pool, BullMQ connection, CertificateVault (per `VAULT_ADDR` presence), HaciendaCRAdapter, XadesEpesVerifier, BullMQ queue + workers, pino logger, OTel tracer, prom-client registry.
+
+- [ ] **Step 4: Implement `composition/mode.ts`** — sidecar vs standalone toggle. Sidecar binds `127.0.0.1:50061` only; standalone binds `0.0.0.0:50061` + `0.0.0.0:8766`.
+
+- [ ] **Step 5: Implement `grpc/server.ts`** — `@grpc/grpc-js` server, registers 4 services (Admin/Inbox/Reporting/Health), installs interceptors (Task 44), starts on configured port.
+
+- [ ] **Step 6: Run**
+
+Run: `pnpm --filter @lapc506/invoice-core-server test grpc-bootstrap`
+Expected: 1 passed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/server/src/grpc/server.ts packages/server/src/composition/
+git commit -m "feat(grpc): add gRPC server bootstrap + DI composition root"
+```
+
+- [ ] **Step 8: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 43 — gRPC bootstrap + composition" \
+  --label "phase/1,scope/grpc,type/feat,priority/p0" \
+  --body "gRPC server on :50061 with DI composition wiring Postgres + Vault + Queue + HaciendaCRAdapter + observability."
+```
+
+---
+
+## Task 44 — gRPC interceptors (tracing, auth, redaction, metrics) + reflection + health
+
+**Files:** `packages/server/src/grpc/interceptors/{tracing,auth,redaction,metrics}.ts` + `packages/server/src/grpc/services/health.ts` + reflection wiring.
+
+- [ ] **Step 1: Failing test `interceptors.spec.ts`**
+
+```ts
+it("auth interceptor rejects calls without mTLS peer cert in sidecar mode", async () => { /* … */ });
+it("redaction interceptor strips PII before handler logs", async () => { /* … */ });
+it("reflection exposes InvoiceAdmin service", async () => {
+  const client = new ReflectionClient(channel);
+  const services = await client.listServices();
+  expect(services).toContain("invoice_core.v1.InvoiceAdmin");
+});
+it("grpc_health_v1.Health reports SERVING when deps healthy", async () => { /* … */ });
+```
+
+- [ ] **Step 2: Implement 4 interceptors**
+
+Each is a `ServerInterceptor` wrapping the next handler. Tracing extracts `traceparent` + starts span; auth validates mTLS peer cert (sidecar) or bearer (REST-only — no gRPC bearer in Fase 1); redaction clones request, redacts PII paths, stores on span attributes; metrics records RPC latency + status.
+
+- [ ] **Step 3: Implement `services/health.ts`** — `grpc_health_v1.Health` with service-level checks: Postgres `SELECT 1`, Redis PING, vault reachability, authority circuit-breaker state.
+
+- [ ] **Step 4: Enable reflection**
+
+Register `grpc-reflection` server side so `grpcurl` + Postman work out of the box.
+
+- [ ] **Step 5: Run**
+
+Run: `pnpm --filter @lapc506/invoice-core-server test interceptors health reflection`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/server/src/grpc/interceptors/ packages/server/src/grpc/services/health.ts
+git commit -m "feat(grpc): add interceptors + reflection + health service"
+```
+
+- [ ] **Step 7: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 44 — gRPC interceptors + reflection + health" \
+  --label "phase/1,scope/grpc,type/feat,security/pii,security/credentials,priority/p0" \
+  --body "Tracing + auth (mTLS) + PII redaction + metrics interceptors; grpc_health_v1.Health; reflection."
+```
+
+---
+
+## Task 45 — gRPC services: InvoiceAdmin + InvoiceInbox wired
+
+**Files:** `packages/server/src/grpc/services/{admin,inbox}.ts` + integration tests.
+
+- [ ] **Step 1: Failing test `admin-service.integration.spec.ts`**
+
+```ts
+it("IssueInvoice RPC returns QUEUED and persists", async () => {
+  const app = await buildTestApp();
+  const ack = await new InvoiceAdminClient(app.channel).issueInvoice(sampleRequest());
+  expect(ack.status).toBe("QUEUED");
+  expect(ack.claveNumerica).toHaveLength(50);
+  await app.close();
+});
+```
+
+- [ ] **Step 2: Implement `admin.ts`** — maps each of the 11 RPCs to its use case (Task 26-28, plus donation/withholding stubs returning `UNIMPLEMENTED`, `CancelDocument`, `GetDocumentStatus`, `ListDocuments` query stream).
+
+- [ ] **Step 3: Implement `inbox.ts`** — 4 RPCs: `IngestInboundDocument` → `ReceiveIncomingDocument` use case; `RespondToInbound` → `RespondToReceiverMessage`; `ListInbound` streams via cursor; `ReconcileWithPO` → `ReconcileDocument`.
+
+- [ ] **Step 4: Run**
+
+Run: `pnpm --filter @lapc506/invoice-core-server test:integration admin-service inbox-service`
+Expected: full RPC round-trip green against dockerized Postgres + Redis.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/server/src/grpc/services/admin.ts packages/server/src/grpc/services/inbox.ts
+git commit -m "feat(grpc): wire InvoiceAdmin + InvoiceInbox services"
+```
+
+- [ ] **Step 6: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 45 — InvoiceAdmin + InvoiceInbox services" \
+  --label "phase/1,scope/grpc,type/feat,priority/p0" \
+  --body "11 Admin RPCs (incl. stubs) + 4 Inbox RPCs wired to use cases. Integration tested against real Postgres + Redis."
+```
+
+---
+
+## Task 46 — gRPC services: InvoiceReporting (stubs) + InvoiceHealth extras
+
+**Files:** `packages/server/src/grpc/services/reporting.ts` + updates to `health.ts`.
+
+- [ ] **Step 1: Failing test `reporting-stubs.spec.ts`**
+
+```ts
+it("ExportD101Casillas returns UNIMPLEMENTED with a pointer to Fase 3", async () => {
+  const res = new InvoiceReportingClient(channel).exportD101Casillas({ period: 2026 });
+  await expect(res).rejects.toMatchObject({ code: status.UNIMPLEMENTED });
+});
+it("ExportDonationsSummary returns UNIMPLEMENTED pointing to Fase 2", async () => { /* … */ });
+it("InvoiceHealth.GetCircuitBreakerState returns current per-authority state", async () => { /* … */ });
+```
+
+- [ ] **Step 2: Implement `reporting.ts`** — 4 RPCs. All return `status.UNIMPLEMENTED` with a `google.rpc.DebugInfo` detail pointing at the Fase that will land the implementation.
+
+- [ ] **Step 3: Extend `health.ts`** with `GetQueueDepth` + `GetCircuitBreakerState` + `CheckAuthorityHealth` RPCs.
+
+- [ ] **Step 4: Run**
+
+Run: `pnpm --filter @lapc506/invoice-core-server test reporting-stubs health-extras`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/server/src/grpc/services/reporting.ts packages/server/src/grpc/services/health.ts
+git commit -m "feat(grpc): add InvoiceReporting stubs + InvoiceHealth extras"
+```
+
+- [ ] **Step 6: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 46 — Reporting stubs + Health extras" \
+  --label "phase/1,scope/grpc,type/feat" \
+  --body "Reporting RPCs return UNIMPLEMENTED pointing to later fases; Health exposes queue depth + CB state + authority health."
+```
+
+---
+
+## Task 47 — Fastify REST `:8766` (standalone-only admin) + webhook route + OpenAPI
+
+**Files:** `packages/server/src/rest/{fastify-app,openapi.yaml}` + `rest/routes/{admin,inbox,webhook-hacienda,health}.ts`.
+
+- [ ] **Step 1: Failing test `rest-admin.spec.ts`**
+
+```ts
+it("POST /v1/invoices with bearer token returns 202 + claveNumerica", async () => {
+  const app = await buildTestApp({ mode: "standalone" });
+  const res = await app.inject({ method: "POST", url: "/v1/invoices", headers: { authorization: "Bearer dev" }, payload: sampleInvoiceBody() });
+  expect(res.statusCode).toBe(202);
+});
+it("POST /v1/invoices without bearer returns 401", async () => { /* … */ });
+it("REST server does not start in sidecar mode", async () => { /* … */ });
+```
+
+- [ ] **Step 2: Implement `fastify-app.ts`** — Fastify 5 with helmet + CORS (configurable) + compress + `@fastify/bearer-auth` for Bearer token from env.
+
+- [ ] **Step 3: Implement `routes/admin.ts`** — admin routes mirror gRPC subset (`POST /v1/invoices`, `POST /v1/credit-notes`, `POST /v1/documents/:id:cancel`, `GET /v1/documents/:id`, `GET /v1/documents?...`).
+
+- [ ] **Step 4: Implement `routes/inbox.ts`** — `GET /v1/inbound`, `POST /v1/inbound/:id:respond`, `POST /v1/inbound/:id:reconcile`.
+
+- [ ] **Step 5: Implement `routes/webhook-hacienda.ts`** — HMAC-verified inbound webhook (reuses adapter from Task 42).
+
+- [ ] **Step 6: Implement `routes/health.ts`** — GET `/healthz` + `/readyz`.
+
+- [ ] **Step 7: Author `rest/openapi.yaml`** describing all routes. Render via Stoplight Elements in docs (Task 57).
+
+- [ ] **Step 8: Run**
+
+Run: `pnpm --filter @lapc506/invoice-core-server test rest`
+Expected: admin + webhook + health green.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/server/src/rest/
+git commit -m "feat(rest): add Fastify REST server (:8766 standalone) + webhook + OpenAPI"
+```
+
+- [ ] **Step 10: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 47 — REST :8766 + OpenAPI" \
+  --label "phase/1,scope/rest,type/feat,security/credentials,priority/p0" \
+  --body "Fastify 5 app: admin + inbox + webhook + health routes. Bearer auth for standalone. OpenAPI spec for docs rendering."
+```
+
+---
+
+## Task 48 — Entry-points: `bin/standalone.ts` + `bin/sidecar.ts` + `bin/migrate.ts` + worker spawners
+
+**Files:** `packages/server/src/bin/{standalone,sidecar,migrate}.ts` + `packages/server/src/workers/{submission,status-poll,inbound-polling,certificate-expiry}.ts`.
+
+- [ ] **Step 1: Failing test `entrypoints.smoke.ts`**
+
+```ts
+it("bin/standalone.ts spawns and binds gRPC + REST; SIGTERM drains cleanly", async () => {
+  const proc = spawn("node", ["dist/bin/standalone.js"], { env: { ...testEnv, DEPLOYMENT_MODE: "standalone" } });
+  await waitForPort(50061);
+  await waitForPort(8766);
+  proc.kill("SIGTERM");
+  const code = await waitExit(proc);
+  expect(code).toBe(0);
+});
+it("bin/sidecar.ts binds only loopback gRPC", async () => { /* … */ });
+it("bin/migrate.ts runs drizzle migrations + CABYS sample ingest", async () => { /* … */ });
+```
+
+- [ ] **Step 2: Implement `bin/standalone.ts`**
+
+Boots `composition.wire()`, starts gRPC + REST, installs SIGTERM handler that drains workers → closes servers → closes Pg/Redis within 30s deadline.
+
+- [ ] **Step 3: Implement `bin/sidecar.ts`** — same as standalone minus REST; binds loopback only.
+
+- [ ] **Step 4: Implement `bin/migrate.ts`** — runs drizzle migrator, then seeds a 100-row CABYS sample if DB empty.
+
+- [ ] **Step 5: Implement worker spawners** under `workers/` that are launched in-process from the entrypoints.
+
+- [ ] **Step 6: Run**
+
+Run: `pnpm --filter @lapc506/invoice-core-server build && pnpm --filter @lapc506/invoice-core-server test:smoke`
+Expected: all entrypoints smoke-green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/server/src/bin/ packages/server/src/workers/
+git commit -m "feat(server): add standalone/sidecar/migrate entrypoints + worker spawners"
+```
+
+- [ ] **Step 8: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 48 — Entrypoints + workers" \
+  --label "phase/1,scope/server,type/feat,priority/p0" \
+  --body "bin/standalone + bin/sidecar + bin/migrate + worker spawners with SIGTERM drain."
+```
+
+---
+
+## Task 49 — Dockerfile multi-stage + .dockerignore
+
+**Files:** `Dockerfile`, `.dockerignore`.
+
+- [ ] **Step 1: Failing test `docker-build.smoke.sh`**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+docker buildx build --check .        # Dockerfile lint via buildx
+IMG=$(docker build -q -t invoice-core:smoke .)
+docker run --rm --entrypoint=node "$IMG" -e "console.log('ok')"
+```
+
+- [ ] **Step 2: Write `Dockerfile`**
+
+Stages:
+- `FROM node:22.11-bookworm-slim AS base` — set PNPM_HOME, install corepack.
+- `FROM base AS deps` — copy manifests + `pnpm install --frozen-lockfile --prod=false`.
+- `FROM deps AS builder` — copy sources, `pnpm proto:gen && pnpm build`.
+- `FROM base AS runtime` — non-root user (`invoice:invoice` UID 10001), copy `packages/*/dist` + pruned `node_modules` via `pnpm deploy`, set `HEALTHCHECK CMD node dist/bin/healthcheck.js`.
+
+- [ ] **Step 3: Write `.dockerignore`** — excludes `node_modules`, `dist`, `coverage`, `.git`, `docs/`, `charts/`, `*.p12`.
+
+- [ ] **Step 4: Run smoke**
+
+```bash
+bash scripts/docker-build.smoke.sh
+```
+
+Expected: image builds ≤ 2 min cold, final image < 300 MB.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Dockerfile .dockerignore scripts/docker-build.smoke.sh
+git commit -m "feat(docker): add multi-stage Dockerfile + smoke test"
+```
+
+- [ ] **Step 6: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 49 — Dockerfile" \
+  --label "phase/1,scope/docker,type/infra" \
+  --body "Multi-stage Node 22 slim image; non-root user; HEALTHCHECK; < 300 MB final layer."
+```
+
+---
+
+## Task 50 — docker-compose for local dev (postgres + redis + vault-dev + otel collector)
+
+**Files:** `docker-compose.yml`, `docker-compose.dev.yml`, `scripts/dev-bootstrap.sh`.
+
+- [ ] **Step 1: Failing test `compose-up.smoke.sh`**
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+# wait for healthchecks
+until [ "$(docker inspect --format='{{.State.Health.Status}}' invoice-core-dev-postgres-1)" = "healthy" ]; do sleep 2; done
+curl -fsS http://localhost:8766/healthz
+docker compose down
+```
+
+- [ ] **Step 2: Write `docker-compose.yml`**
+
+Services: `invoice-core` (built locally), `postgres:16-alpine` with healthcheck, `redis:7-alpine` with healthcheck, `hashicorp/vault:1.18` in dev mode, `otel/opentelemetry-collector-contrib:latest` (OTLP → stdout), `prom/prometheus` scraping `:9465`, `grafana/grafana` with invoice-core dashboards mounted.
+
+- [ ] **Step 3: Write `docker-compose.dev.yml`** — dev overrides: source mounted as volume, `command: ["pnpm","--filter","@lapc506/invoice-core-server","dev"]`, vault seeded with a dev `.p12`.
+
+- [ ] **Step 4: Write `scripts/dev-bootstrap.sh`**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+pnpm install
+pnpm proto:gen
+pnpm --filter @lapc506/invoice-core-server build
+node packages/server/dist/bin/migrate.js
+vault kv put -mount=secret invoice-core/certificates/dev @fixtures/dev.p12
+```
+
+- [ ] **Step 5: Run**
+
+```bash
+bash scripts/compose-up.smoke.sh
+```
+
+Expected: all services healthy; REST `/healthz` returns 200.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docker-compose.yml docker-compose.dev.yml scripts/dev-bootstrap.sh scripts/compose-up.smoke.sh
+git commit -m "feat(docker): add dev compose stack + bootstrap + smoke"
+```
+
+- [ ] **Step 7: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 50 — docker-compose dev stack" \
+  --label "phase/1,scope/docker,type/infra" \
+  --body "Compose stack: invoice-core + postgres + redis + vault-dev + otel-collector + prometheus + grafana. dev-bootstrap.sh seeds vault + migrates DB."
+```
+
+---
+
+## Task 51 — Helm chart skeleton `charts/invoice-core/`
+
+**Files:** `charts/invoice-core/{Chart.yaml,values.yaml}` + `templates/{deployment,service,configmap,sealed-secret,servicemonitor,ingress,pdb}.yaml`.
+
+- [ ] **Step 1: Failing test `helm-lint.sh`**
+
+```bash
+helm lint charts/invoice-core
+helm template test charts/invoice-core --values charts/invoice-core/values.test.yaml | kubeconform -strict
+```
+
+- [ ] **Step 2: Write `Chart.yaml`**
+
+```yaml
+apiVersion: v2
+name: invoice-core
+description: Electronic invoicing sidecar for Costa Rica + MX retention + CO retention
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+```
+
+- [ ] **Step 3: Write `values.yaml`** covering: `image.repository`, `image.tag`, `image.pullPolicy`, `mode: sidecar|standalone`, `resources.requests/limits`, `env.*`, `postgres.dsn`, `redis.url`, `vault.*`, `servicemonitor.enabled`, `ingress.*` (standalone only), `podSecurityContext`, `networkPolicy.*`.
+
+- [ ] **Step 4: Write templates**
+
+- `deployment.yaml` — supports mode toggle (sidecar injects alongside a host container via `sharedProcessNamespace: true`; standalone uses own Deployment).
+- `service.yaml` — ClusterIP on `50061` + `8766` (standalone) / headless (sidecar).
+- `configmap.yaml` — non-secret env.
+- `sealed-secret.yaml` — template for Vault/sealed-secrets `.p12` + bearer token.
+- `servicemonitor.yaml` — Prometheus Operator scrape on `:9465`.
+- `ingress.yaml` — gated on `ingress.enabled` (standalone).
+- `pdb.yaml` — PodDisruptionBudget minAvailable=1.
+
+- [ ] **Step 5: Run**
+
+Run: `bash scripts/helm-lint.sh`
+Expected: lint clean + kubeconform passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add charts/invoice-core/ scripts/helm-lint.sh
+git commit -m "feat(helm): add invoice-core chart skeleton (sidecar + standalone modes)"
+```
+
+- [ ] **Step 7: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 51 — Helm chart" \
+  --label "phase/1,scope/helm,type/infra" \
+  --body "Chart supports sidecar + standalone. Deployment/Service/ConfigMap/SealedSecret/ServiceMonitor/Ingress/PDB templates. Lints clean."
+```
+
+---
+
+## Task 52 — K8s sidecar manifest example (consumer-side reference)
+
+**Files:** `examples/k8s/sidecar/{habitanexus-backend-with-invoice-core.yaml,kustomization.yaml}`.
+
+- [ ] **Step 1: Failing test `sidecar-manifest.smoke.sh`**
+
+```bash
+kubectl apply --dry-run=client -f examples/k8s/sidecar/habitanexus-backend-with-invoice-core.yaml
+kubeconform -strict examples/k8s/sidecar/habitanexus-backend-with-invoice-core.yaml
+```
+
+- [ ] **Step 2: Author manifest**
+
+Two-container Pod:
+- `habitanexus-backend` (placeholder image) calls `grpc://127.0.0.1:50061`.
+- `invoice-core` container (our image) runs `bin/sidecar.js`, mounts `sealed-secret` with `.p12` + bearer.
+- `shareProcessNamespace: false` (loopback gRPC sufficient).
+- NetworkPolicy denies egress except Hacienda CR API + Postgres + Redis + Vault.
+
+- [ ] **Step 3: Run**
+
+Run: `bash scripts/sidecar-manifest.smoke.sh`
+Expected: dry-run OK + kubeconform clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples/k8s/sidecar/ scripts/sidecar-manifest.smoke.sh
+git commit -m "feat(helm): add sidecar example manifest for consumer backends"
+```
+
+- [ ] **Step 5: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 52 — Sidecar example manifest" \
+  --label "phase/1,scope/helm,type/infra,type/docs" \
+  --body "Reference Pod spec for consumer backends (HabitaNexus, AltruPets, Vertivolatam, AduaNext) running invoice-core as sidecar on 127.0.0.1:50061."
+```
+
+---
+
+## Task 53 — Standalone deployment manifest example
+
+**Files:** `examples/k8s/standalone/{deployment,service,ingress,networkpolicy}.yaml`.
+
+- [ ] **Step 1: Failing test `standalone-manifest.smoke.sh`**
+
+```bash
+kubectl apply --dry-run=client -k examples/k8s/standalone/
+kubeconform -strict examples/k8s/standalone/*.yaml
+```
+
+- [ ] **Step 2: Author manifests**
+
+- `deployment.yaml` — 2 replicas, `bin/standalone.js`, probes on `/healthz` + `/readyz`.
+- `service.yaml` — ClusterIP exposing `50061` + `8766` + `9465`.
+- `ingress.yaml` — routes `invoice.<cluster-domain>` to REST `:8766` with cert-manager TLS.
+- `networkpolicy.yaml` — ingress limited to trusted CIDRs; egress to Hacienda + Postgres + Redis + Vault.
+
+- [ ] **Step 3: Run**
+
+Run: `bash scripts/standalone-manifest.smoke.sh`
+Expected: dry-run OK + kubeconform clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples/k8s/standalone/ scripts/standalone-manifest.smoke.sh
+git commit -m "feat(helm): add standalone example manifests"
+```
+
+- [ ] **Step 5: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 53 — Standalone example manifest" \
+  --label "phase/1,scope/helm,type/infra" \
+  --body "2-replica standalone Deployment + Service + Ingress + NetworkPolicy."
+```
+
+---
+
+## Task 54 — CI smoke: container boots + health ping
+
+**Files:** update `.github/workflows/ci.yml` (add `docker-smoke` job) + `scripts/ci-health-smoke.sh`.
+
+- [ ] **Step 1: Failing test — author `scripts/ci-health-smoke.sh`**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+docker compose -f docker-compose.yml up -d postgres redis
+docker build -t invoice-core:ci .
+docker run -d --name ic --network host -e DATABASE_URL=postgres://invoice:invoice@localhost:5432/invoice_core -e REDIS_URL=redis://localhost:6379 -e DEPLOYMENT_MODE=standalone invoice-core:ci
+for i in {1..30}; do curl -fsS http://localhost:8766/healthz && break; sleep 2; done
+curl -fsS http://localhost:8766/healthz
+docker logs ic | grep -q "gRPC server listening on :50061"
+```
+
+- [ ] **Step 2: Add `docker-smoke` CI job**
+
+```yaml
+docker-smoke:
+  runs-on: ubuntu-latest
+  needs: [build]
+  steps:
+    - uses: actions/checkout@v4
+    - run: bash scripts/ci-health-smoke.sh
+```
+
+- [ ] **Step 3: Add `helm-lint` CI job**
+
+```yaml
+helm-lint:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: azure/setup-helm@v4
+    - run: helm lint charts/invoice-core
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml scripts/ci-health-smoke.sh
+git commit -m "ci: add docker-smoke + helm-lint jobs"
+```
+
+- [ ] **Step 5: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 54 — CI smoke + helm lint" \
+  --label "phase/1,scope/ci,type/test" \
+  --body "Container boots and answers /healthz in CI; helm chart lints on every PR."
+```
+
+---
+
+
+## Task 55 — Zensical/MyST docs site skeleton
+
+**Files:** `mkdocs.yml`, `docs/index.md`, `docs/getting-started.md`, `docs/architecture.md`.
+
+- [ ] **Step 1: Failing test `docs-build.sh`**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+pip install --user mkdocs-material mkdocs-material-extensions mkdocs-macros-plugin myst-parser
+mkdocs build --strict
+```
+
+- [ ] **Step 2: Write `mkdocs.yml`**
+
+```yaml
+site_name: invoice-core
+theme:
+  name: material
+  features: [navigation.tabs, content.code.copy, content.tabs.link]
+plugins: [search, macros]
+markdown_extensions:
+  - admonition
+  - pymdownx.superfences
+  - pymdownx.tabbed
+  - pymdownx.snippets
+  - myst_parser
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Architecture: architecture.md
+  - API Reference:
+      - gRPC: api-reference/grpc.md
+      - REST (Stoplight): api-reference/rest.md
+  - Adapters:
+      - Hacienda CR: adapters/hacienda-cr.md
+  - Operations:
+      - Deployment: operations/deployment.md
+      - Observability: operations/observability.md
+```
+
+- [ ] **Step 3: Write `docs/index.md`** — landing with spec summary + Fase 1 scope + quick-install blurb.
+
+- [ ] **Step 4: Write `docs/architecture.md`** — pulls Mermaid diagrams from spec §3.
+
+- [ ] **Step 5: Run**
+
+Run: `bash scripts/docs-build.sh`
+Expected: `site/` directory built without warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mkdocs.yml docs/index.md docs/getting-started.md docs/architecture.md scripts/docs-build.sh
+git commit -m "docs: add MkDocs Material + MyST site skeleton"
+```
+
+- [ ] **Step 7: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 55 — Docs site skeleton" \
+  --label "phase/1,scope/docs,type/docs" \
+  --body "MkDocs Material + MyST. Home, Getting Started, Architecture (pulls spec Mermaids), scaffolds for API reference + adapters + operations."
+```
+
+---
+
+## Task 56 — Stoplight Elements embed for REST OpenAPI rendering (reuse across lapc506 startups)
+
+**Files:** `docs/api-reference/rest.md`, `docs/_overrides/partials/stoplight.html`.
+
+- [ ] **Step 1: Failing test `docs-rest-embed.sh`**
+
+```bash
+mkdocs build --strict
+grep -q "stoplight-elements" site/api-reference/rest/index.html
+```
+
+- [ ] **Step 2: Author Stoplight embed**
+
+`docs/api-reference/rest.md`:
+
+```markdown
+# REST API
+
+<elements-api apiDescriptionUrl="/openapi.yaml" router="hash" layout="sidebar" />
+
+<script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css">
+```
+
+- [ ] **Step 3: Copy `packages/server/src/rest/openapi.yaml` to `docs/openapi.yaml`** via mkdocs `include` plugin or a small build hook.
+
+- [ ] **Step 4: Extract the Stoplight block to a partial** `docs/_overrides/partials/stoplight.html` so habitanexus/altrupets/vertivolatam/aduanext docs can reuse it via `--theme.custom_dir`.
+
+- [ ] **Step 5: Run**
+
+Run: `bash scripts/docs-rest-embed.sh`
+Expected: `site/api-reference/rest/index.html` contains the Stoplight web component tag.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/api-reference/rest.md docs/_overrides/partials/stoplight.html scripts/docs-rest-embed.sh
+git commit -m "docs: embed Stoplight Elements for REST API rendering (reusable across lapc506 startups)"
+```
+
+- [ ] **Step 7: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 56 — Stoplight Elements embed" \
+  --label "phase/1,scope/docs,type/docs" \
+  --body "REST docs render via Stoplight Elements. Reusable partial so HabitaNexus/AltruPets/Vertivolatam/AduaNext docs get the same treatment per lapc506 convention."
+```
+
+---
+
+## Task 57 — README with quickstart (sidecar + standalone)
+
+**Files:** `README.md`.
+
+- [ ] **Step 1: Failing test `readme-links.sh`**
+
+```bash
+#!/usr/bin/env bash
+# Fail if README references paths or scripts that do not exist.
+set -euo pipefail
+for p in "docker-compose.yml" "charts/invoice-core/Chart.yaml" "scripts/dev-bootstrap.sh" "examples/k8s/sidecar/habitanexus-backend-with-invoice-core.yaml" "docs/getting-started.md"; do
+  test -e "$p" || { echo "Missing: $p"; exit 1; }
+done
+```
+
+- [ ] **Step 2: Author `README.md`** with sections:
+
+- Badges (CI, version, BSL 1.1 licence, Node 22).
+- Short value prop (3 lines from spec §1).
+- Quickstart sidecar: 6-command sequence (`helm install invoice-core ./charts/invoice-core --set mode=sidecar ...`).
+- Quickstart standalone: 6-command sequence (`docker compose up`).
+- Supported documents table (7 CR types + MX/CO retention stubs).
+- Ports table (`:50061`, `:8766`, `:9465`).
+- Pointer to full docs (`docs/getting-started.md`) and spec (`docs/superpowers/specs/...`).
+- Licence + contribution pointers.
+
+- [ ] **Step 3: Run**
+
+Run: `bash scripts/readme-links.sh`
+Expected: exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md scripts/readme-links.sh
+git commit -m "docs: add README with sidecar + standalone quickstarts"
+```
+
+- [ ] **Step 5: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 57 — README quickstart" \
+  --label "phase/1,scope/docs,type/docs" \
+  --body "README with BSL 1.1 badge, sidecar + standalone quickstarts, supported docs table, ports table."
+```
+
+---
+
+## Task 58 — CONTRIBUTING.md + SECURITY.md
+
+**Files:** `CONTRIBUTING.md`, `SECURITY.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `.github/ISSUE_TEMPLATE/bug_report.yml`, `.github/ISSUE_TEMPLATE/feature_request.yml`.
+
+- [ ] **Step 1: Failing test `governance-files.sh`**
+
+```bash
+test -f CONTRIBUTING.md
+test -f SECURITY.md
+test -f .github/PULL_REQUEST_TEMPLATE.md
+test -f .github/ISSUE_TEMPLATE/bug_report.yml
+test -f .github/ISSUE_TEMPLATE/feature_request.yml
+grep -q "BSL 1.1" CONTRIBUTING.md
+grep -q "andres@dojocoding.io" SECURITY.md
+```
+
+- [ ] **Step 2: Author `CONTRIBUTING.md`** covering: BSL 1.1 CLA-less policy, Conventional Commits, TDD + coverage thresholds, per-task worktree isolation + `superpowers:executing-plans` loop, Linear + GitHub issue cross-link convention, PR checklist.
+
+- [ ] **Step 3: Author `SECURITY.md`** covering: reporting channel `andres@dojocoding.io` + PGP key link, response SLA (72h ack), scope (production + sandbox), CVD policy, `.p12`/cert handling warning.
+
+- [ ] **Step 4: Author PR + issue templates** — checklist mirroring spec §10 testing strategy + §12 security review.
+
+- [ ] **Step 5: Run**
+
+Run: `bash scripts/governance-files.sh`
+Expected: exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CONTRIBUTING.md SECURITY.md .github/PULL_REQUEST_TEMPLATE.md .github/ISSUE_TEMPLATE/ scripts/governance-files.sh
+git commit -m "docs: add CONTRIBUTING + SECURITY + templates"
+```
+
+- [ ] **Step 7: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 58 — CONTRIBUTING + SECURITY" \
+  --label "phase/1,scope/docs,type/docs,security/credentials" \
+  --body "BSL 1.1 contribution policy; SECURITY.md with andres@dojocoding.io reporting + CVD; PR + issue templates."
+```
+
+---
+
+## Task 59 — Adapter + operations docs
+
+**Files:** `docs/adapters/hacienda-cr.md`, `docs/operations/deployment.md`, `docs/operations/observability.md`.
+
+- [ ] **Step 1: Failing test `adapter-docs-build.sh`**
+
+```bash
+mkdocs build --strict
+for f in adapters/hacienda-cr operations/deployment operations/observability; do
+  test -f "site/${f}/index.html"
+done
+```
+
+- [ ] **Step 2: Author `adapters/hacienda-cr.md`** — describes SDK wrap strategy, supported doc types, circuit-breaker behaviour, sandbox vs production env vars.
+
+- [ ] **Step 3: Author `operations/deployment.md`** — sidecar install (`helm install`), standalone install (`docker compose`), secret rotation (hot-reload), migration playbook.
+
+- [ ] **Step 4: Author `operations/observability.md`** — metrics catalogue from §11, log paths redacted per §12, OTel exporter config, example Grafana dashboard JSON link.
+
+- [ ] **Step 5: Run**
+
+Run: `bash scripts/adapter-docs-build.sh`
+Expected: all three pages rendered.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/adapters/ docs/operations/ scripts/adapter-docs-build.sh
+git commit -m "docs: add hacienda-cr adapter + deployment + observability docs"
+```
+
+- [ ] **Step 7: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 59 — Adapter + operations docs" \
+  --label "phase/1,scope/docs,type/docs" \
+  --body "Hacienda CR adapter + deployment + observability (metrics catalogue + PII redaction paths)."
+```
+
+---
+
+## Task 60 — BSL 1.1 LICENSE + release v0.1.0 tag wiring
+
+**Files:** `LICENSE`, `.github/workflows/release.yml`, `CHANGELOG.md`.
+
+- [ ] **Step 1: Failing test `license-check.sh`**
+
+```bash
+test -f LICENSE
+grep -q "Business Source License 1.1" LICENSE
+grep -q "Change Date:" LICENSE
+grep -q "Change License:" LICENSE
+```
+
+- [ ] **Step 2: Author `LICENSE`** — BSL 1.1 template populated for `invoice-core` with: Licensor `Luis Andres Pena Castillo`, Change Date `2030-04-16` (4-year horizon per memory `feedback_bsl_license.md`), Change License `Apache-2.0`, Additional Use Grant: production use for organisations ≤ USD 1M ARR.
+
+- [ ] **Step 3: Author `.github/workflows/release.yml`** — triggers on tags `v*.*.*`, publishes container to GHCR, publishes `@lapc506/invoice-core-core` + `@lapc506/invoice-core-proto` + `@lapc506/invoice-core-server` to npm via `pnpm publish -r --access public`.
+
+- [ ] **Step 4: Author `CHANGELOG.md`** — seed with Fase 1 scope header.
+
+- [ ] **Step 5: Run**
+
+Run: `bash scripts/license-check.sh`
+Expected: exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add LICENSE .github/workflows/release.yml CHANGELOG.md scripts/license-check.sh
+git commit -m "chore: add BSL 1.1 LICENSE + release workflow + CHANGELOG"
+```
+
+- [ ] **Step 7: Retro GitHub issue**
+
+```bash
+gh issue create --repo lapc506/invoice-core \
+  --title "[Fase 1] Task 60 — LICENSE + release workflow" \
+  --label "phase/1,scope/ci,type/chore" \
+  --body "BSL 1.1 with 2030-04-16 Change Date (Apache-2.0). Release workflow publishes container + npm packages on v*.*.* tags."
+```
+
+---
+
+## Self-review — Fase 1 spec coverage
+
+- [ ] **§3 Architecture**: hexagonal layout present. Primary adapters gRPC (`:50061`) + REST (`:8766`) wired; 17 ports defined — 5 fully wired (`DocumentRepositoryPort`, `TaxpayerRepositoryPort`, `SequenceRepositoryPort`, `CABYSRepositoryPort`, `CertificateVaultPort`, `TaxAuthorityPort`, `ReceiverMessagePort`, `InboundDocumentGatewayPort`, `SignatureVerifierPort`, `EventPublisherPort`, `ClockPort`, `IdGeneratorPort`, `RetryQueuePort`, `PIIRedactorPort`, `ReconciliationEnginePort`), 6 deferred as stubs.
+- [ ] **§3.3 Deployment modes**: `bin/standalone.ts` + `bin/sidecar.ts` (Task 48) + Helm mode toggle (Task 51).
+- [ ] **§4 Domain**: Document base + 9 subtypes (Invoice, Ticket, CreditNote, DebitNote, PurchaseInvoice, ExportInvoice, ReceiverMessage, DonationReceipt stub, WithholdingCertificate stub), Taxpayer + ForeignReceiver, DocumentSequence, LineItem + TaxLine + TaxBreakdown, Dispute.
+- [ ] **§4.3 State machine**: Task 20 service with transition tests.
+- [ ] **§5 Ports**: 17 port interfaces present; contract suites for 5 fully-wired ports.
+- [ ] **§6 Proto**: 4 services, buf codegen, UNIMPLEMENTED stubs for Reporting + Donation/Withholding admin RPCs.
+- [ ] **§7 Adapters**: CR full via `HaciendaCRAdapter`. MX PAC + CO DIAN deferred to Fase 5/6 (port interfaces only).
+- [ ] **§9 Capability matrix**: Fase 1 rows (P0) all covered — emission 01/02/03/04/08, Mensaje Receptor, recepción + reconciliación scaffold, queue + retry + circuit breaker, CABYS, IVA + retenciones calc in domain, observability, gRPC + REST sidecar/standalone.
+- [ ] **§11 Observability**: pino + OTel + prom-client with §11 metrics (Task 41).
+- [ ] **§12 Security**: `.p12` via CertificateVault (Task 38), PII redaction in logs (Task 41 + middleware Task 31), mTLS interceptor (Task 44), HMAC webhooks (Task 47), BSL 1.1 licence (Task 60).
+- [ ] **§14 Fase 1 roadmap**: every deliverable mapped to tasks.
+
+Gaps deliberately deferred (each has a later-fase home):
+
+- D-101 / D-104 / D-103 export **stubbed** in Reporting RPCs (Fase 3 `FilingDataExportPort`).
+- `DonationAuthorizationPort` + `AppraisalPort` full adapters deferred to Fase 2.
+- `CustomsDataPort` full adapter deferred to Fase 3.
+- PAC MX (`PACMexicoAdapter`) deferred to Fase 5.
+- DIAN CO (`DIANColombiaAdapter`) deferred to Fase 6.
+- Multi-tenant `.p12` per taxpayer deferred (single-tenant per operator; tipo 08 handles growers).
+- `OCRPort` full adapter deferred (P2).
+- Event-driven emission bridge to blockchain deferred (P3).
+
+If any check fails, open a follow-up issue `[Fase 1] gap: <topic>` before declaring Fase 1 done.
+
+---
+
+## Execution handoff
+
+- Primary sub-skill: **`superpowers:subagent-driven-development`** to fan tasks out in parallel where dependencies allow. Alternative: **`superpowers:executing-plans`** for sequential execution with review checkpoints, or `/make-no-mistakes:implement` over Linear issue IDs once GitHub issues are cross-linked.
+- Git strategy: one branch per task (`feat/task-NN-<slug>`), open draft PR with the task checklist copied, merge when all checkboxes green + CI passes. Rebase onto `main` before merge.
+- Worktree isolation: follow `superpowers:using-git-worktrees` when multiple tasks run in parallel to avoid cross-branch pollution.
+- Review rhythm: after every 10 tasks (i.e., after 20, 30, 40, 50, 60), pause for a governance review against the rubric criteria; adjust plan if findings emerge.
+- Dependency order highlights:
+  - Tasks 1-6 (tooling + scaffold) must land before any domain task.
+  - Tasks 7-21 (domain) can be parallelised task-by-task but must precede application tasks.
+  - Tasks 22-25 (ports) must land before 26-31 (use cases).
+  - Task 32 (proto) must land before 43-47 (gRPC + REST).
+  - Tasks 33-42 (adapters) can be parallelised but must land before 45 (Admin/Inbox wire them).
+  - Tasks 49-54 (infra) depend on server build being green (Task 48).
+  - Tasks 55-60 (docs + licence) can run in parallel with infra once the API surface is stable.
+- Done criteria: all 60 tasks merged, CI green, `helm install invoice-core ./charts/invoice-core` works against a `kind` cluster, `IssueInvoice` E2E against Hacienda CR sandbox completes, docs render cleanly, LICENSE in place.
+
+---
+
+## Appendix A — Bulk issue creation script
+
+`scripts/create-github-issues.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Bulk-create all Fase 1 issues on lapc506/invoice-core.
+# Requires: gh auth login, labels already created via create-github-labels.sh (Task 5).
+set -euo pipefail
+
+REPO="lapc506/invoice-core"
+PHASE_LABEL="phase/1"
+
+create() {
+  local number="$1" title="$2" labels="$3" body="$4"
+  gh issue create \
+    --repo "$REPO" \
+    --title "[Fase 1] Task ${number} — ${title}" \
+    --label "${PHASE_LABEL},${labels}" \
+    --body "${body}"
+}
+
+create  1 "pnpm workspace scaffold"              "scope/scaffold,type/chore"                    "Initialize pnpm monorepo with strict tsconfig, Node 22 pin, env template."
+create  2 "Biome lint + format"                  "scope/ci,type/chore"                          "Biome config with strict rules (no any, no console, no non-null)."
+create  3 "Vitest + coverage thresholds"         "scope/ci,type/chore"                          "Root Vitest config enforcing ≥95% domain coverage."
+create  4 "CI workflow"                          "scope/ci,type/chore"                          "Matrix CI: lint, typecheck, test, proto, build."
+create  5 "Labels taxonomy"                      "scope/ci,type/chore"                          "Bootstrap GitHub label taxonomy (phase/scope/type/security/priority)."
+create  6 "Core package skeleton"                "scope/scaffold,type/chore"                    "Scaffold packages/core with tsup + subpath exports."
+create  7 "Base value objects"                   "scope/domain,type/feat"                       "UUID + ISODateTime + ISODate + Decimal."
+create  8 "Money/Jurisdiction/Country/Unit VOs"  "scope/domain,type/feat"                       "Money ISO4217; Jurisdiction/Country/UnitCode enums."
+create  9 "PIIString VO"                         "scope/domain,type/feat,security/pii"          "Safe-by-default PII wrapper."
+create 10 "TaxId VO"                             "scope/domain,type/feat,security/pii"          "CR física/jurídica/DIMEX/NITE + MX RFC + CO NIT."
+create 11 "CABYS + GTIN + ClaveNumerica"         "scope/domain,type/feat,security/signature"    "CABYS 13-digit + GTIN mod10 + clave 50-digit mod11."
+create 12 "Taxpayer + ForeignReceiver"           "scope/domain,type/feat,security/pii"          "Taxpayer aggregate; ForeignReceiver for non-local ids."
+create 13 "LineItem + TaxLine + TaxBreakdown"    "scope/domain,type/feat"                       "Line items with optional customs + traceability; IVA rates; aggregator."
+create 14 "DocumentSequence aggregate"           "scope/domain,type/feat,security/signature"    "Per (taxpayer,branch,terminal,docType) monotonic consecutivo."
+create 15 "Document base + Invoice + Ticket"    "scope/domain,type/feat"                       "Abstract base + 01/04 subtypes."
+create 16 "CreditNote + DebitNote"               "scope/domain,type/feat"                       "NC/ND (02/03) with referential integrity."
+create 17 "PurchaseInvoice 08 + ExportInvoice 09" "scope/domain,type/feat"                      "Factura-compra + Export skeleton."
+create 18 "ReceiverMessage + Withholding/Donation stubs" "scope/domain,type/feat"               "MR full; Withholding + Donation stubs throw NotImplementedInFase1."
+create 19 "Dispute aggregate"                    "scope/domain,type/feat"                       "OPEN→ESCALATED→RESOLVED/REJECTED states."
+create 20 "Domain services (state/totals/clave)" "scope/domain,type/feat,security/signature"    "State machine + totals + clave builder with mod11."
+create 21 "Domain events + errors barrel"        "scope/domain,type/feat,security/pii"          "9 events + typed errors; zero PII in payloads."
+create 22 "Persistence ports"                    "scope/app,type/feat"                          "Document/Taxpayer/Sequence/CABYS repository ports + contracts."
+create 23 "Authority + inbound ports"            "scope/app,type/feat"                          "TaxAuthority/ReceiverMessage/InboundGateway/SignatureVerifier ports + contracts."
+create 24 "Infrastructure ports"                 "scope/app,type/feat,security/credentials"     "CertificateVault/EventPublisher/Clock/IdGenerator/RetryQueue/PIIRedactor/ReconciliationEngine."
+create 25 "Deferred port stubs"                  "scope/app,type/feat"                          "Donation/Appraisal/Customs/Filing/OCR/AccountingSink interfaces + UnimplementedInFase1."
+create 26 "IssueInvoice use case"                "scope/app,type/feat,priority/p0"              "Primary emission: lookup → seq → clave → persist → enqueue → emit. Idempotent."
+create 27 "Credit/Debit + Cancel"                "scope/app,type/feat"                          "NC/ND emission + CancelDocument orchestrator."
+create 28 "Ticket + PurchaseInvoice + Export"    "scope/app,type/feat"                          "Three subtype use cases."
+create 29 "Inbound + Mensaje Receptor"           "scope/app,type/feat,priority/p0"              "ReceiveIncomingDocument + RespondToReceiverMessage."
+create 30 "ReconcileDocument"                    "scope/app,type/feat"                          "Fase 1 in-memory reconciliation engine."
+create 31 "Middleware chain"                     "scope/app,type/feat,security/pii,priority/p0" "Tracing + auth + idempotency + metrics + PII redaction."
+create 32 "Proto codegen pipeline"               "scope/proto,type/feat"                        "buf lint + breaking + codegen; 4 services declared."
+create 33 "HaciendaCRAdapter (builders + signer)" "scope/hacienda-cr,type/feat,security/credentials,priority/p0" "Wraps @dojocoding/hacienda-sdk; 7 builders; SDK errors → domain errors."
+create 34 "Submitter + StatusPoller + metrics"   "scope/hacienda-cr,type/feat"                  "Exponential backoff + terminal-state poll + Prometheus metrics."
+create 35 "Postgres schema + migrations"         "scope/postgres,type/feat,security/pii"        "8 tables via Drizzle; claveNumerica unique index; JSONB payload."
+create 36 "DocumentRepositoryPg + TaxpayerRepositoryPg" "scope/postgres,type/feat,priority/p0"  "Pass shared port contracts."
+create 37 "SequenceRepositoryPg + CABYS"         "scope/postgres,type/feat,security/signature,priority/p0" "Advisory-lock gap-free consecutivo (100-parallel test) + trigram CABYS search + CSV ingester."
+create 38 "CertificateVault"                     "scope/vault,type/feat,security/credentials,priority/p0" "Vault + sealed-secrets + local-FS; Disposable buffers; expiry monitor."
+create 39 "XAdES-EPES verifier"                  "scope/signature,type/feat,security/signature,priority/p0" "Canonicalization + digest + signature + cert chain + policy hash."
+create 40 "RetryQueue + workers + circuit breaker" "scope/queue,type/feat,priority/p0"          "BullMQ + opossum (50%/20/30s); submission + status-poll workers."
+create 41 "pino + OTel + prom-client"            "scope/otel,type/feat,security/pii,priority/p0" "Logger with redact paths; OTel SDK; Prometheus registry for §11 metrics."
+create 42 "InboundDocumentGateway"               "scope/inbound,type/feat,security/signature"   "Webhook (HMAC) + 5-min polling worker."
+create 43 "gRPC bootstrap + composition"         "scope/grpc,type/feat,priority/p0"             "gRPC :50061 + DI composition root."
+create 44 "gRPC interceptors + reflection + health" "scope/grpc,type/feat,security/pii,security/credentials,priority/p0" "Tracing + auth + redaction + metrics; reflection; grpc_health_v1."
+create 45 "InvoiceAdmin + InvoiceInbox services" "scope/grpc,type/feat,priority/p0"             "11 Admin RPCs + 4 Inbox RPCs wired; integration tested."
+create 46 "Reporting stubs + Health extras"      "scope/grpc,type/feat"                         "Reporting UNIMPLEMENTED (→ Fase 3); queue + CB + authority health."
+create 47 "REST :8766 + OpenAPI"                 "scope/rest,type/feat,security/credentials,priority/p0" "Fastify admin + inbox + webhook + health."
+create 48 "Entrypoints + workers"                "scope/server,type/feat,priority/p0"           "bin/standalone + bin/sidecar + bin/migrate + worker spawners."
+create 49 "Dockerfile"                           "scope/docker,type/infra"                      "Multi-stage Node 22 slim; non-root; HEALTHCHECK; <300 MB."
+create 50 "docker-compose dev stack"             "scope/docker,type/infra"                      "invoice-core + postgres + redis + vault + otel + prometheus + grafana."
+create 51 "Helm chart"                           "scope/helm,type/infra"                        "Sidecar + standalone modes; Deployment/Service/ConfigMap/SealedSecret/ServiceMonitor/Ingress/PDB."
+create 52 "Sidecar example manifest"             "scope/helm,type/infra,type/docs"              "Reference Pod spec for consumer backends."
+create 53 "Standalone example manifest"          "scope/helm,type/infra"                        "2-replica Deployment + Service + Ingress + NetworkPolicy."
+create 54 "CI smoke + helm lint"                 "scope/ci,type/test"                           "Container boots and answers /healthz; chart lints."
+create 55 "Docs site skeleton"                   "scope/docs,type/docs"                         "MkDocs Material + MyST; Home/Getting Started/Architecture."
+create 56 "Stoplight Elements embed"             "scope/docs,type/docs"                         "Reusable REST docs partial across lapc506 startups."
+create 57 "README quickstart"                    "scope/docs,type/docs"                         "Sidecar + standalone quickstarts; ports + doc type tables."
+create 58 "CONTRIBUTING + SECURITY"              "scope/docs,type/docs,security/credentials"    "BSL 1.1 policy + SECURITY reporting + PR/issue templates."
+create 59 "Adapter + operations docs"            "scope/docs,type/docs"                         "hacienda-cr + deployment + observability docs."
+create 60 "LICENSE + release workflow"           "scope/ci,type/chore"                          "BSL 1.1 (Change Date 2030-04-16, Apache-2.0) + release on v*.*.*."
+
+echo "Created 60 Fase 1 issues on ${REPO}."
+```
+
+Make executable: `chmod +x scripts/create-github-issues.sh`. Run after Task 5 (labels exist).
+
+---
+
+## Appendix B — Labels bootstrap script (summary)
+
+Full script lives at `scripts/create-github-labels.sh` (Task 5). Label matrix:
+
+| Namespace | Labels |
+|---|---|
+| `phase/` | `phase/1`, `phase/2`, `phase/3`, `phase/4`, `phase/5`, `phase/6` |
+| `scope/` | `scope/scaffold`, `scope/proto`, `scope/domain`, `scope/app`, `scope/hacienda-cr`, `scope/postgres`, `scope/vault`, `scope/queue`, `scope/signature`, `scope/inbound`, `scope/otel`, `scope/grpc`, `scope/rest`, `scope/server`, `scope/docker`, `scope/helm`, `scope/docs`, `scope/ci` |
+| `type/` | `type/feat`, `type/fix`, `type/chore`, `type/docs`, `type/test`, `type/refactor`, `type/infra` |
+| `security/` | `security/pii`, `security/credentials`, `security/signature` |
+| `priority/` | `priority/p0`, `priority/p1`, `priority/p2` |
+
+Script uses `gh label create ... --force` (idempotent) so it is safe to re-run.


### PR DESCRIPTION
Two docs-only commits:

1. `docs(architecture): archive eventbus-broker-analysis.md` — brings the eventbus broker analysis doc into version control (previously lived outside the repo).
2. `docs(plans): add Fase 1 implementation plan (60 tasks)` — TDD-driven plan with 5-step task template per task, Appendix A bulk-creates GitHub issues, Appendix B documents label taxonomy.

Zero code changes. Intended to land on main before `/make-no-mistakes:implement` execution begins on issues #3-#12 (Tasks 1-10).