### PR TITLE
chore(ci): Biome lint + formatter config

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "organizeImports": { "enabled": true },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": { "noExplicitAny": "error", "noConsoleLog": "error" },
+      "style": { "useConst": "error", "noNonNullAssertion": "error" },
+      "complexity": { "noForEach": "off" }
+    }
+  },
+  "files": {
+    "ignore": ["**/dist", "**/coverage", "**/generated", "**/*.sql", "**/__fixtures__/**"]
+  }
+}


### PR DESCRIPTION
## Summary

Implements **plan Task 2** — see [`docs/superpowers/plans/2026-04-16-invoice-core-phase-1-plan.md` §Task 2](../blob/main/docs/superpowers/plans/2026-04-16-invoice-core-phase-1-plan.md#task-2--biome-lint--format-config).

- `biome.json` — Biome 1.9.4 config. Strict rules on: `noExplicitAny`, `noConsoleLog`, `useConst`, `noNonNullAssertion`. `noForEach` turned off.
- `packages/.gitkeep` — keeps the empty workspace dir tracked so `pnpm install` does not warn.

## Test plan

- [x] `pnpm install` succeeds
- [x] `pnpm lint` → `Checked 3 files. No fixes applied.` (lints biome.json + package.json + tsconfig.base.json)
- [ ] CI wiring comes in Task 4 (issue #6)

Closes #4

---

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>