### PR TITLE
chore(ci): Vitest config + coverage thresholds

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: false,
+    include: ["packages/**/*.{test,spec}.ts"],
+    exclude: ["**/dist/**", "**/generated/**", "**/*.integration.spec.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html", "lcov"],
+      thresholds: {
+        "packages/core/src/domain/**": {
+          lines: 95,
+          functions: 95,
+          statements: 95,
+          branches: 90,
+        },
+        "packages/core/src/app/**": {
+          lines: 85,
+          functions: 85,
+          statements: 85,
+          branches: 80,
+        },
+      },
+      exclude: ["**/generated/**", "**/*.test.ts", "**/*.spec.ts", "**/__fixtures__/**"],
+    },
+    setupFiles: ["./vitest.setup.ts"],
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,14 @@
+import { afterEach, vi } from "vitest";
+
+/**
+ * Opt-in fake clock helper. Tests that need determinism call
+ * `useFixedClock("2026-04-16T12:00:00Z")`.
+ */
+export function useFixedClock(iso: string): void {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(iso));
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});


### PR DESCRIPTION
## Summary

Implements **plan Task 3** — see [`docs/superpowers/plans/2026-04-16-invoice-core-phase-1-plan.md` §Task 3](../blob/main/docs/superpowers/plans/2026-04-16-invoice-core-phase-1-plan.md#task-3--vitest-root-config--coverage-thresholds).

- `vitest.config.ts` — root Vitest config. Includes `packages/**/*.{test,spec}.ts`, excludes `*.integration.spec.ts`. Coverage via v8 with text + html + lcov reporters. Per-path thresholds: domain >=95/95/95/90; app >=85/85/85/80.
- `vitest.setup.ts` — exports `useFixedClock(iso)` helper; resets timers after each test.

## Test plan

- [x] Smoke test created → `pnpm test` → 1 passed (then deleted)
- [ ] Real coverage thresholds kick in at Task 7 (VO tests)
- [ ] CI wiring comes in Task 4 (issue #6)

Closes #5

---

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>