### PR TITLE
feat(domain): Money + Jurisdiction + CountryCode + UnitCode VOs

### DIFF
--- a/packages/core/src/domain/value-objects/country-code.spec.ts
+++ b/packages/core/src/domain/value-objects/country-code.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { CountryCode } from "./country-code.js";
+
+describe("CountryCode", () => {
+  it.each(["CR", "MX", "CO", "US", "DE", "JP"])("accepts ISO 3166-1 alpha-2 %s", (c) => {
+    expect(CountryCode.parse(c)).toBe(c);
+  });
+  it("rejects lowercase", () => {
+    expect(() => CountryCode.parse("cr")).toThrow();
+  });
+  it("rejects wrong length", () => {
+    expect(() => CountryCode.parse("CRI")).toThrow();
+    expect(() => CountryCode.parse("C")).toThrow();
+  });
+  it("rejects non-letters", () => {
+    expect(() => CountryCode.parse("C1")).toThrow();
+  });
+});

--- a/packages/core/src/domain/value-objects/country-code.ts
+++ b/packages/core/src/domain/value-objects/country-code.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+const schema = z
+  .string()
+  .length(2)
+  .regex(/^[A-Z]{2}$/);
+
+export type CountryCode = string & { readonly __brand: "CountryCode" };
+
+export const CountryCode = {
+  parse(input: unknown): CountryCode {
+    return schema.parse(input) as CountryCode;
+  },
+};

--- a/packages/core/src/domain/value-objects/jurisdiction.spec.ts
+++ b/packages/core/src/domain/value-objects/jurisdiction.spec.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { Jurisdiction } from "./jurisdiction.js";
+
+describe("Jurisdiction", () => {
+  it.each(["CR", "MX", "CO", "US", "GLOBAL"] as const)("accepts %s", (j) => {
+    expect(Jurisdiction.parse(j)).toBe(j);
+  });
+  it("rejects unknown jurisdiction", () => {
+    expect(() => Jurisdiction.parse("BR")).toThrow();
+  });
+});

--- a/packages/core/src/domain/value-objects/jurisdiction.ts
+++ b/packages/core/src/domain/value-objects/jurisdiction.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const JURISDICTIONS = ["CR", "MX", "CO", "US", "GLOBAL"] as const;
+export type Jurisdiction = (typeof JURISDICTIONS)[number];
+
+const schema = z.enum(JURISDICTIONS);
+
+export const Jurisdiction = {
+  parse(input: unknown): Jurisdiction {
+    return schema.parse(input);
+  },
+};

--- a/packages/core/src/domain/value-objects/money.spec.ts
+++ b/packages/core/src/domain/value-objects/money.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { Decimal } from "./decimal.js";
+import { InvalidMoney, Money } from "./money.js";
+
+describe("Money", () => {
+  it("creates with ISO 4217 currency", () => {
+    const m = Money.of(Decimal.fromString("100.00"), "CRC");
+    expect(m.currency).toBe("CRC");
+    expect(m.amount.toString()).toBe("100.00");
+  });
+  it("rejects unknown currency", () => {
+    expect(() => Money.of(Decimal.fromString("1"), "ZZZ")).toThrow(InvalidMoney);
+  });
+  it("refuses add across currencies", () => {
+    const crc = Money.of(Decimal.fromString("1"), "CRC");
+    const usd = Money.of(Decimal.fromString("1"), "USD");
+    expect(() => crc.add(usd)).toThrow(/currency mismatch/);
+  });
+  it("refuses sub across currencies", () => {
+    const crc = Money.of(Decimal.fromString("1"), "CRC");
+    const usd = Money.of(Decimal.fromString("1"), "USD");
+    expect(() => crc.sub(usd)).toThrow(/currency mismatch/);
+  });
+  it("add in same currency sums amounts", () => {
+    const a = Money.of(Decimal.fromString("1.50"), "USD");
+    const b = Money.of(Decimal.fromString("0.25"), "USD");
+    expect(a.add(b).amount.toString()).toBe("1.75");
+  });
+  it("sub in same currency subtracts amounts", () => {
+    const a = Money.of(Decimal.fromString("2.00"), "MXN");
+    const b = Money.of(Decimal.fromString("0.50"), "MXN");
+    expect(a.sub(b).amount.toString()).toBe("1.50");
+  });
+  it("toString contains amount and currency", () => {
+    expect(Money.of(Decimal.fromString("100.00"), "COP").toString()).toBe("100.00 COP");
+  });
+});

--- a/packages/core/src/domain/value-objects/money.ts
+++ b/packages/core/src/domain/value-objects/money.ts
@@ -1,0 +1,44 @@
+import type { Decimal } from "./decimal.js";
+
+/**
+ * ISO 4217 currencies supported in Fase 1. Extended per phase in the roadmap.
+ * CRC = Costa Rican colón, MXN = Mexican peso, COP = Colombian peso.
+ */
+const ALLOWED = new Set(["CRC", "USD", "EUR", "MXN", "COP"]);
+
+export class Money {
+  private constructor(
+    public readonly amount: Decimal,
+    public readonly currency: string,
+  ) {}
+
+  static of(amount: Decimal, currency: string): Money {
+    if (!ALLOWED.has(currency)) throw new InvalidMoney(`currency ${currency}`);
+    return new Money(amount, currency);
+  }
+
+  add(other: Money): Money {
+    if (this.currency !== other.currency) {
+      throw new InvalidMoney(`currency mismatch: ${this.currency} vs ${other.currency}`);
+    }
+    return new Money(this.amount.add(other.amount), this.currency);
+  }
+
+  sub(other: Money): Money {
+    if (this.currency !== other.currency) {
+      throw new InvalidMoney(`currency mismatch: ${this.currency} vs ${other.currency}`);
+    }
+    return new Money(this.amount.sub(other.amount), this.currency);
+  }
+
+  toString(): string {
+    return `${this.amount.toString()} ${this.currency}`;
+  }
+}
+
+export class InvalidMoney extends Error {
+  constructor(msg: string) {
+    super(`Invalid money: ${msg}`);
+    this.name = "InvalidMoney";
+  }
+}

--- a/packages/core/src/domain/value-objects/unit-code.spec.ts
+++ b/packages/core/src/domain/value-objects/unit-code.spec.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { UnitCode } from "./unit-code.js";
+
+describe("UnitCode", () => {
+  it.each(["Sp", "Unid", "kg", "m", "kWh"] as const)("accepts subset code %s", (u) => {
+    expect(UnitCode.parse(u)).toBe(u);
+  });
+  it("rejects unknown code", () => {
+    expect(() => UnitCode.parse("parsec")).toThrow();
+  });
+});

--- a/packages/core/src/domain/value-objects/unit-code.ts
+++ b/packages/core/src/domain/value-objects/unit-code.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+/**
+ * Subset of the Hacienda v4.4 unit-of-measure catalog used in Fase 1.
+ * The full catalog lands via ingester in a later phase (Fase 3 — see
+ * Task 37 in the implementation plan).
+ */
+export const UNIT_CODES = [
+  "Sp",
+  "Unid",
+  "kg",
+  "g",
+  "m",
+  "cm",
+  "mm",
+  "l",
+  "ml",
+  "m2",
+  "m3",
+  "h",
+  "d",
+  "kWh",
+  "Al",
+  "Alc",
+  "I",
+  "St",
+  "Os",
+] as const;
+export type UnitCode = (typeof UNIT_CODES)[number];
+
+const schema = z.enum(UNIT_CODES);
+
+export const UnitCode = {
+  parse(input: unknown): UnitCode {
+    return schema.parse(input);
+  },
+};


### PR DESCRIPTION
## Summary

Implements plan Task 8 — see docs/superpowers/plans/2026-04-16-invoice-core-phase-1-plan.md §Task 8.

Four additional domain value objects:

- Money — immutable class wrapping Decimal + ISO 4217 currency. Allowlist for Fase 1: CRC, USD, EUR, MXN, COP. add() / sub() enforce same-currency invariant via InvalidMoney.
- Jurisdiction — enum over CR, MX, CO, US, GLOBAL. Drives per-country tax rules.
- CountryCode — branded string, ISO 3166-1 alpha-2 (two uppercase letters).
- UnitCode — enum over the Fase-1 subset of Hacienda v4.4 catalog (Sp, Unid, kg, g, m, cm, mm, l, ml, m2, m3, h, d, kWh, Al, Alc, I, St, Os). Full catalog ingests in Fase 3 (plan Task 37).

## Coverage

100 % lines / statements / functions on all four new modules. Overall domain branch coverage 96.55 %. Thresholds pass.

## Test plan

- pnpm test — 51 tests pass
- pnpm typecheck — green
- pnpm lint — green
- pnpm test -- --coverage — thresholds cleared

Closes #10